### PR TITLE
Prepare migration to W3C organization

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+All documentation, code and communication under this repository are covered by the [W3C Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,32 @@
 # Contributing
 
+Please refer to the group's [Work Mode](https://www.w3.org/wiki/Second_Screen/Work_Mode).
+
+Contributions to this repository are intended to become part of Recommendation-track documents governed by the
+[W3C Patent Policy](http://www.w3.org/Consortium/Patent-Policy-20040205/) and
+[Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software).
+To make substantive contributions to specifications, you must either participate
+in the relevant W3C Working Group or make a non-member patent licensing commitment.
+
+If you are not the sole contributor to a contribution (pull request), please identify all
+contributors in the pull request comment.
+
+To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
+
+```
++@github_username
+```
+
+If you added a contributor by mistake, you can remove them in a comment with:
+
+```
+-@github_username
+```
+
+If you are making a pull request on behalf of someone else but you had no part in designing the
+feature, you can remove yourself with the above syntax.
+
+
 ## Bikeshed 
 
 The Open Screen Protocol spec is maintained with

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,2 @@
+All documents in this Repository are licensed by contributors under the [W3C
+Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software).

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ and [Remote Playback API](https://w3c.github.io/remote-playback/)
 in an interoperable fashion.
 
 This work is in scope for the
-[W3C Second Screen Community Group](https://www.w3.org/community/webscreens/)
-([Charter](https://webscreens.github.io/cg-charter/)).
+[W3C Second Screen Working Group](https://www.w3.org/2014/secondscreen/)
+([Charter](https://www.w3.org/2014/secondscreen/charter-2020.html)).
+
+Please refer to the group's [Work Mode](https://www.w3.org/wiki/Second_Screen/Work_Mode)
+for instructions on how to contribute.
 
 The protocol will meet the
 [functional and non-functional requirements](requirements.md) of the
@@ -18,7 +21,7 @@ for prospective implementations.
 
 ### Submitted Proposals
 
-The community group is currently evaluating proposals to implement different
+The group is currently evaluating proposals to implement different
 aspects of the Open Screen Protocol.  The following proposals have been
 submitted:
 

--- a/index.bs
+++ b/index.bs
@@ -3,30 +3,17 @@ Title: Open Screen Protocol
 Shortname: openscreenprotocol
 Level: 1
 Status: w3c/ED
-ED: https://webscreens.github.io/openscreenprotocol/
+ED: https://w3c.github.io/openscreenprotocol/
 Canonical URL: ED
 Editor: Mark Foltz, Google, https://github.com/mfoltzgoogle, w3cid 68454
-Repository: webscreens/openscreenprotocol
+Repository: w3c/openscreenprotocol
 Abstract: The Open Screen Protocol is a suite of network protocols that allow
           user agents to implement the [[PRESENTATION-API|Presentation API]] and
           the [[REMOTE-PLAYBACK|Remote Playback API]] in an interoperable
           fashion.
-Group: Second Screen Community Group
-Mailing List: public-webscreens@w3c.org
-Mailing List Archives: https://lists.w3.org/Archives/Public/public-webscreens/
+Group: secondscreenwg
 Markup Shorthands: markdown yes, dfn yes, idl yes, markup yes
 </pre>
-
-<p boilerplate="copyright">
-<a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">
-  Copyright</a> © [YEAR] the Contributors to the [TITLE] Specification,
-  published by the <a href="https://www.w3.org/community/webscreens/">
-  Second Screen Community Group</a> under the
-  <a href="https://www.w3.org/community/about/agreements/cla/">
-  W3C Community Contributor License Agreement (CLA)</a>.  A human-readable
-  <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a>
-  is available.
-</p>
 
 <pre class="anchors">
 urlPrefix: https://w3c.github.io/presentation-api/#dfn-; type: dfn; spec: PRESENTATION-API
@@ -60,21 +47,6 @@ url: https://tools.ietf.org/html/rfc8122#section-5; type: dfn; spec: RFC8122; te
 url: https://tools.ietf.org/html/rfc8122#section-5; type: dfn; spec: RFC8122; text: md5
 url: https://tools.ietf.org/html/rfc6381#section-3; type: dfn; spec: RFC6381; text: codecs parameter
 </pre>
-
-<h2 class='no-num no-toc no-ref' id='document-status'>Status of this document</h2>
-
-This specification was published by the [Second Screen Community
-Group](https://www.w3.org/community/webscreens/). It is not a W3C Standard nor
-is it on the W3C Standards Track. It should not be viewed as a stable
-specification, and may change in substantial ways at any time. A future version
-of this document will be published as a Community Group Report.
-
-Please note that under the [W3C Community Contributor License Agreement
-(CLA)](https://www.w3.org/community/about/agreements/cla/) there is a limited
-opt-out and other conditions apply.
-
-Learn more about [W3C Community and Business
-Groups](http://www.w3.org/community/).
 
 Introduction {#introduction}
 ============================

--- a/index.bs
+++ b/index.bs
@@ -519,7 +519,7 @@ The various capabilities have the following meanings:
 :: The agent can send streaming using the streaming protocol.
 
 Note: See the
-[Capabilities Registry](https://webscreens.github.io/openscreenprotocol/capabilities.md)
+[Capabilities Registry](https://w3c.github.io/openscreenprotocol/capabilities.md)
 for a list of all known capabilities (both defined by this specification, and
 through [[#protocol-extensions]]).
 
@@ -2222,7 +2222,7 @@ customization or other purposes.
 
 To add new extension messages, extension authors must register a capability ID
 with a range of message type keys in a
-[public registry](https://webscreens.github.io/openscreenprotocol/capabilites.md).
+[public registry](https://w3c.github.io/openscreenprotocol/capabilites.md).
 Agents may then indicate that they accept an extension by including the
 corresponding capability ID in the `capabilities` field of its [=agent-info=]
 message.

--- a/w3c.json
+++ b/w3c.json
@@ -1,0 +1,9 @@
+{
+  "group": [
+    "74168"
+  ],
+  "contacts": [
+    "tidoust"
+  ],
+  "repo-type": "rec-track"
+}


### PR DESCRIPTION
Add required boilerplate files (code of conduct, license, w3c.json file) and update contributing rules and README to point to W3C's patent policy and Second Screen WG.

Also turn the draft spec into a proper WG Editor's Draft with the right copyright and license.

Note generation will only produce the right boilerplate once https://github.com/tabatkins/bikeshed/pull/1568 gets merged into Bikeshed. This PR should also only be merged once the transfer to `w3c/openscreenprotocol` is completed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/openscreenprotocol/pull/238.html" title="Last updated on Dec 12, 2019, 5:33 PM UTC (329c99e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webscreens/openscreenprotocol/238/c7cb098...tidoust:329c99e.html" title="Last updated on Dec 12, 2019, 5:33 PM UTC (329c99e)">Diff</a>