### PR TITLE
Fix a typo and dfn autolink

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1509,7 +1509,7 @@ All times, time ranges, and durations (such as position, duration, and
 seekable-time-ranges) used above use a common [=media-time=] value (see Appendix A)
 which includes a time scale.  This allows time values which work on different
 time scales to be expressed without loss of precision.  The scale is represented
-in hertz, such as 90000 for 90000hz, a common time scale for video.
+in hertz, such as 90000 for 90000 Hz, a common time scale for video.
 
 <div class="note">
 <table>
@@ -1880,7 +1880,7 @@ any point and notify the sender by sending a
 Audio {#streaming-audio}
 ------------------------------
 
-[Media senders=] may send audio to [=media receivers=] by sending
+[=Media senders=] may send audio to [=media receivers=] by sending
 [=audio-frame=] messages (see [[#appendix-a]]) with the following keys and
 values.  An audio frame message contains a set of encoded audio samples for a
 range of time. A series of encoded audio frames that share a codec, codec


### PR DESCRIPTION
Just a few drive-by editorial fixes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/245.html" title="Last updated on Oct 19, 2020, 5:06 PM UTC (15592e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/245/5312e98...15592e2.html" title="Last updated on Oct 19, 2020, 5:06 PM UTC (15592e2)">Diff</a>