### PR TITLE
Editorial: fix reference to CDDL.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -46,6 +46,7 @@ url: https://tools.ietf.org/html/rfc8122#section-5; type: dfn; spec: RFC8122; te
 url: https://tools.ietf.org/html/rfc8122#section-5; type: dfn; spec: RFC8122; text: md2
 url: https://tools.ietf.org/html/rfc8122#section-5; type: dfn; spec: RFC8122; text: md5
 url: https://tools.ietf.org/html/rfc6381#section-3; type: dfn; spec: RFC6381; text: codecs parameter
+url: https://tools.ietf.org/html/rfc8610#section-3; type: dfn; spec: RFC8610; text: concise data definition language
 </pre>
 
 Introduction {#introduction}
@@ -2595,12 +2596,12 @@ capable of handling:
 Appendix A: Messages {#appendix-a}
 ====================
 
-The following messages are defined with [[RFC8610|CDDL]]. When integer keys are used, a
-comment is appended to the line to indicate the name of the field. Object
-definitions in this specification have this unusual syntax to reduce the number
-of bytes-on-the-wire, while maintaining a human-readable name for each
-key. Integer keys are used instead of object arrays to allow for easy indexing
-of optional fields.
+The following messages are defined using the [=Concise Data Definition
+Language=] syntax. When integer keys are used, a comment is appended to the line
+to indicate the name of the field. Object definitions in this specification have
+this unusual syntax to reduce the number of bytes-on-the-wire, while maintaining
+a human-readable name for each key. Integer keys are used instead of object
+arrays to allow for easy indexing of optional fields.
 
 Each root message (one that can be put into a QUIC stream without being enclosed
 by another message) has a comment indicating the message type key.


### PR DESCRIPTION
RFC8610 is not included in the Bikeshed bibliographic database yet.  Instead use a direct reference to the relevant section of the RFC.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/247.html" title="Last updated on Oct 19, 2020, 9:32 PM UTC (261bbc2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/247/d966069...261bbc2.html" title="Last updated on Oct 19, 2020, 9:32 PM UTC (261bbc2)">Diff</a>