### PR TITLE
Update reference to CBOR RFC.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -552,7 +552,7 @@ include additional information not defined in this spec, as described in
 Messages delivery using CBOR and QUIC streams {#messages}
 ========================================================
 
-Messages are serialized using [[!RFC7049|CBOR]].  To send a group of messages in
+Messages are serialized using [[!RFC8949|CBOR]].  To send a group of messages in
 order, that group of messages must be sent in one QUIC stream.  Independent
 groups of messages (with no ordering dependency across groups) should be sent in
 different QUIC streams.  In order to put multiple CBOR-serialized messages into


### PR DESCRIPTION
RFC 7049 has been replaced by standards-track [RFC 8949](https://tools.ietf.org/html/rfc8949).  According to RFC 8949,

```
This document obsoletes RFC 7049, providing editorial improvements,
new details, and errata fixes while keeping full compatibility with
the interchange format of RFC 7049.  It does not create a new version
of the format.
```

Therefore we can just refer to the new RFC.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/251.html" title="Last updated on Feb 23, 2021, 1:25 AM UTC (94c7613)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/251/ef6f97e...94c7613.html" title="Last updated on Feb 23, 2021, 1:25 AM UTC (94c7613)">Diff</a>