### PR TITLE
Specify coding of mv.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -33,9 +33,10 @@ urlPrefix: https://w3c.github.io/remote-playback/#dfn-; type: dfn; spec: REMOTE-
     text: media resources
     text: remote playback devices
     text: remote playback source
-url: https://tools.ietf.org/html/draft-ietf-quic-transport-23#section-18; type: dfn; spec: QUIC; text: Transport Parameter Encoding
-url: https://tools.ietf.org/html/draft-ietf-quic-transport-23#section-19.19; type: dfn; spec: QUIC; text: CONNECTION_CLOSE Frames
-url: https://tools.ietf.org/html/draft-ietf-quic-transport-23#section-16; type: dfn; spec: QUIC; text: Variable-Length Integer Encoding
+url: https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-18; type: dfn; spec: QUIC; text: Transport Parameter Encoding
+url: https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-19.19; type: dfn; spec: QUIC; text: CONNECTION_CLOSE Frames
+url: https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-16; type: dfn; spec: QUIC; text: Variable-Length Integer Encoding
+url: https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-16; type: dfn; spec: QUIC; text: variable-length integer
 url: https://tools.ietf.org/html/rfc6762#section-9; type: dfn; spec: RFC6762; text: conflict resolution
 url: https://tools.ietf.org/html/rfc6763#section-7; type: dfn; spec: RFC6763; text: service name
 url: https://tools.ietf.org/html/rfc6763#section-4.1.1; type: dfn; spec: RFC6763; text: instance name
@@ -281,7 +282,8 @@ keys and values:
 :: An unsigned integer value that indicates that
     metadata has changed.   The advertising agent must update it to a greater
     value.  This signals to the listening agent that it should connect to the
-    advertising agent to discover updated metadata.
+    advertising agent to discover updated metadata.  The value should be encoded
+    as a [=variable-length integer=].
 
 : at
 :: An alphanumeric, unguessable token consisting of characters from the set
@@ -560,8 +562,8 @@ the the same QUIC stream, the following is used.
 
 For each message, the [=OSP agent=] must write to the QUIC stream the following:
 
-1.  A type key representing the type of the message, encoded as a variable-length
-    integer (see [[#appendix-a]] for type keys)
+1.  A type key representing the type of the message, encoded as a [=variable-length
+    integer=] (see [[#appendix-a]] for type keys)
 
 2.  The message encoded as CBOR.
 
@@ -2625,7 +2627,7 @@ Appendix B: Message Type Key Ranges {#appendix-b}
 The following appendix describes how the range of message type keys is divided.
 Legal values are 1 to 2<sup>64</sup>.
 
-Each type key is encoded as a variable-length integer on the wire of 1, 2, 4 or
+Each type key is encoded as a [=variable-length integer=] on the wire of 1, 2, 4 or
 8 bytes.  For each wire byte size, 1/4 to 1/2 of the keys are available for
 extensions.
 


### PR DESCRIPTION
The `mv` parameter advertised through mDNS holds the metadata version, and is incremented each time the agent's metadata is changed.  This PR addresses issue #239 and specifies that it should be encoded as a QUIC variable-length integer, which is the same encoding we use throughout the protoocol.

It also updates cross references to point to the current RFC for QUIC.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/253.html" title="Last updated on Mar 1, 2021, 9:57 PM UTC (e3654e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/253/bf5f659...e3654e8.html" title="Last updated on Mar 1, 2021, 9:57 PM UTC (e3654e8)">Diff</a>