### PR TITLE
Add link to Issue 233.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1631,12 +1631,14 @@ Formats are composed of the following fields:
 : name (required)
 :: The name of the codec.   This must be a single-codec RFC 6381 [=codecs parameter=].
 
-Issue(266): Specify where codec-specific parameters are defined or drop them.
+Issue(233): Use the same codec names as the media APIs.
 
 : parameters (required)
 :: A list of (key, value) parameters that can be used to describe
     properties of a specific format, and not shared by other formats
     of that type (audio, video, etc.).
+
+Issue(266): Specify where codec-specific parameters are defined or drop them.
 
 Audio capabilities are composed of the above format type, with the following
 additional fields:


### PR DESCRIPTION
This adds an inline link to Issue #233 (Use the same codec names as the media APIs) which was left out of PR #267 since it wasn't labeled _v1-spec_.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/268.html" title="Last updated on Mar 3, 2021, 6:30 PM UTC (4154285)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/268/45df70d...4154285.html" title="Last updated on Mar 3, 2021, 6:30 PM UTC (4154285)">Diff</a>