### PR TITLE
Convert HTMLMediaElements links to autolinks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -16,6 +16,12 @@ Markup Shorthands: markdown yes, dfn yes, idl yes, markup yes
 </pre>
 
 <pre class="anchors">
+url: https://html.spec.whatwg.org/multipage/media.html#concept-mediaerror-code; type: dfn; spec: html
+    text: media error code
+urlPrefix: https://html.spec.whatwg.org/multipage/media.html#; type: dfn; spec: html
+    text: official playback position
+    text: poster frame
+    text: timeline offset
 urlPrefix: https://w3c.github.io/presentation-api/#dfn-; type: dfn; spec: PRESENTATION-API
     text: available presentation display
     text: controlling user agent
@@ -1143,40 +1149,42 @@ The receiver should send a [=remote-playback-state-event=] message whenever:
 
 Any of the following methods are called:
 
-* [HtmlMediaElement.fastSeek()](https://html.spec.whatwg.org/multipage/media.html#dom-media-fastseek)
-* [HtmlMediaElement.pause()](https://html.spec.whatwg.org/multipage/media.html#dom-media-pause)
-* [HtmlMediaElement.play()](https://html.spec.whatwg.org/multipage/media.html#dom-media-play)
+* {{HTMLMediaElement/fastSeek()|HTMLMediaElement.fastSeek()}}
+* {{HTMLMediaElement/pause()|HTMLMediaElement.pause()}}
+* {{HTMLMediaElement/play()|HTMLMediaElement.play()}}
 
 Any of the following attributes observably change since the last sent [=remote-playback-state-event=] message:
 
-* [HtmlMediaElement.currentSrc](https://html.spec.whatwg.org/multipage/media.html#dom-media-currentsrc)
-* [HtmlMediaElement.networkState](https://html.spec.whatwg.org/multipage/media.html#dom-media-networkstate)
-* [HtmlMediaElement.readyState](https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate)
-* [HtmlMediaElement.error](https://html.spec.whatwg.org/multipage/media.html#dom-media-error)
-* [HtmlMediaElement's timeline offset](https://html.spec.whatwg.org/multipage/media.html#timeline-offset)
-* [HtmlMediaElement.duration](https://html.spec.whatwg.org/multipage/media.html#dom-media-duration)
-* [HtmlMediaElement.buffered](https://html.spec.whatwg.org/multipage/media.html#dom-media-buffered)
-* [HtmlMediaElement.seekable](https://html.spec.whatwg.org/multipage/media.html#dom-media-seekable)
-* [HtmlMediaElement.playbackRate](https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate)
-* [HtmlMediaElement.paused](https://html.spec.whatwg.org/multipage/media.html#dom-media-paused)
-* [HtmlMediaElement.seeking](https://html.spec.whatwg.org/multipage/media.html#dom-media-seeking)
-* [HtmlMediaElement.stalled](https://html.spec.whatwg.org/multipage/media.html#event-media-stalled)
-* [HtmlMediaElement.ended](https://html.spec.whatwg.org/multipage/media.html#dom-media-ended)
-* [HtmlMediaElement.volume](https://html.spec.whatwg.org/multipage/media.html#dom-media-volume)
-* [HtmlMediaElement.muted](https://html.spec.whatwg.org/multipage/media.html#dom-media-muted)
-* [HtmlMediaElement.videoWidth](https://html.spec.whatwg.org/multipage/media.html#dom-media-videowidth)
-* [HtmlMediaElement.videoHeight](https://html.spec.whatwg.org/multipage/media.html#dom-media-videoheight)
-* [HtmlMediaElement.audioTracks](https://html.spec.whatwg.org/multipage/media.html#dom-media-audiotracks)
-* [HtmlMediaElement.videoTracks](https://html.spec.whatwg.org/multipage/media.html#dom-media-videotracks)
-* [HtmlMediaElement.textTracks](https://html.spec.whatwg.org/multipage/media.html#dom-media-videotracks)
+* {{HTMLMediaElement/currentSrc|HTMLMediaElement.currentSrc}}
+* {{HTMLMediaElement/networkState|HTMLMediaElement.networkState}}
+* {{HTMLMediaElement/readyState|HTMLMediaElement.readyState}}
+* {{HTMLMediaElement/error!!attribute|HTMLMediaElement.error}}
+* {{HTMLMediaElement/duration|HTMLMediaElement.duration}}
+* {{HTMLMediaElement/buffered|HTMLMediaElement.buffered}}
+* {{HTMLMediaElement/seekable|HTMLMediaElement.seekable}}
+* {{HTMLMediaElement/playbackRate|HTMLMediaElement.playbackRate}}
+* {{HTMLMediaElement/paused|HTMLMediaElement.paused}}
+* {{HTMLMediaElement/seeking!!attribute|HTMLMediaElement.seeking}}
+* {{HTMLMediaElement/ended!!attribute|HTMLMediaElement.ended}}
+* {{HTMLMediaElement/volume|HTMLMediaElement.volume}}
+* {{HTMLMediaElement/muted|HTMLMediaElement.muted}}
+* {{HTMLMediaElement/audioTracks|HTMLMediaElement.audioTracks}}
+* {{HTMLMediaElement/videoTracks|HTMLMediaElement.videoTracks}}
+* {{HTMLMediaElement/textTracks|HTMLMediaElement.textTracks}}
+* {{HTMLVideoElement/videoWidth|HTMLVideoElement.videoWidth}}
+* {{HTMLVideoElement/videoHeight|HTMLVideoElement.videoHeight}}
+
+The [=timeline offset=] associated with the playback changes since the last sent [=remote-playback-state-event=] message:
+
+The {{stalled}} event needs to fire at the associated {{HTMLMediaElement}} instance.
 
 More than 350ms pass since the last [=remote-playback-state-event=] message
   and any of the following attributes observably change since the last
   [=remote-playback-state-event=] message. Any new continuously changing
   attributes fall under this rule.
 
-* [HtmlMediaElement.played](https://html.spec.whatwg.org/multipage/media.html#dom-media-played)
-* [HtmlMediaElement.currentTime](https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime)
+* {{HTMLMediaElement/played|HTMLMediaElement.played}}
+* {{HTMLMediaElement/currentTime|HTMLMediaElement.currentTime}}
 
 : remote-playback-id
 :: The ID of the remote playback whose state has changed.
@@ -1230,11 +1238,11 @@ control value or many control values at once without having to specify all
 control values every time.  A non-present control value indicates no change.  A
 present control value indicates the change defined below. These controls
 intentionally mirror settable attributes and methods of the
-[HtmlMediaElement](https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement).
+{{HTMLMediaElement}}.
 
 : source-url
 :: Change the [=media resource=] URL. See
-    [HtmlMediaElement.src](https://html.spec.whatwg.org/multipage/media.html#dom-media-src)
+    {{HTMLMediaElement/src|HTMLMediaElement.src}}
     for more details. Must not be used in the initial controls of the
     [=remote-playback-start-request=] message (which already contains a list of URLs).
     
@@ -1242,7 +1250,7 @@ Issue(223): Codec switching when remoting.
 
 : preload
 :: Set how aggressively to preload media. See
-    [HtmlMediaElement.preload](https://html.spec.whatwg.org/multipage/media.html#dom-media-preload)
+    {{HTMLMediaElement/preload|HTMLMediaElement.preload}}
     for more details. Should only be used in the initial controls of the
     [=remote-playback-start-request=] message or when the source is changed.  If not
     set in the initial controls, it is left to the receiver to decide.  This is
@@ -1251,51 +1259,51 @@ Issue(223): Codec switching when remoting.
 
 : loop
 :: Set whether or not to loop media. See
-    [HtmlMediaElement.loop](https://html.spec.whatwg.org/multipage/media.html#dom-media-loop)
+    {{HTMLMediaElement/loop|HTMLMediaElement.loop}}
     for more details. Should only be used in the initial control of the
     [=remote-playback-start-request=].  If not set in the initial controls, it is
     assumed to be false.
 
 : paused
 :: If true, pause; if false, resume. See
-    [HtmlMediaElement.pause()](https://html.spec.whatwg.org/multipage/media.html#dom-media-pause)
+    {{HTMLMediaElement/pause()|HTMLMediaElement.pause()}}
     and
-    [HtmlMediaElement.play()](https://html.spec.whatwg.org/multipage/media.html#dom-media-play)
+    {{HTMLMediaElement/play()|HTMLMediaElement.play()}}
     for more details.  If not set in the initial controls, it is left to the
     receiver to decide.
 
 : muted
 :: If true, mute; if false, unmute. See
-    [HtmlMediaElement.muted](https://html.spec.whatwg.org/multipage/media.html#dom-media-muted)
+    {{HTMLMediaElement/muted|HTMLMediaElement.muted}}
     for more details.  If not set in the initial controls, it is left to the
     receiver to decide.
 
 : volume
 :: Set the audio volume in the range from 0.0 to 1.0 inclusive. See
-    [HtmlMediaElement.volume](https://html.spec.whatwg.org/multipage/media.html#dom-media-volume)
+    {{HTMLMediaElement/volume|HTMLMediaElement.volume}}
     for more details.  If not set in the initial controls, it is left to the
     receiver to decide.
 
 : seek
 :: Seek to a precise time. See
-    [HtmlMediaElement.currentTime](https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime)
+    {{HTMLMediaElement/currentTime|HTMLMediaElement.currentTime}}
     for more details.
 
 : fast-seek
 :: Seek to an approximate time as fast as possible. See
-    [HtmlMediaElement.fastSeek()](https://html.spec.whatwg.org/multipage/media.html#dom-media-fastseek)
+    {{HTMLMediaElement/fastSeek()|HTMLMediaElement.fastSeek()}}
     for more details.
 
 : playback-rate
 :: Set the rate a which the media plays. See
-    [HtmlMediaElement.playbackRate](https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate)
+    {{HTMLMediaElement/playbackRate|HTMLMediaElement.playbackRate}}
     for more details.  If not set in the initial controls, it is left to the
     receiver to decide.  This is optional for the receiver to support and if not
     supported, the receiver will behave as though it were never set.
 
 : poster
 :: Set the URL of an image to show when video data is not available. See
-    [HtmlMediaElement.poster](https://html.spec.whatwg.org/multipage/media.html#dom-media-poster)
+    [=poster frame=]
     for more details. If not set in the initial controls, no poster is used and
     the receiver can choose what to render when video data is unavailable.  This
     is optional for the receiver to support and if not supported, the receiver
@@ -1303,31 +1311,31 @@ Issue(223): Codec switching when remoting.
 
 : enabled-audio-track-ids
 :: Enable included audio tracks by ID and disable all other audio tracks. See
-    [HtmlMediaElement.audioTracks](https://html.spec.whatwg.org/multipage/media.html#dom-media-audiotracks)
+    {{HTMLMediaElement/audioTracks|HTMLMediaElement.audioTracks}}
     for more details.
 
 : selected-video-track-id
 :: Select the given video track by ID and unselect all other video tracks. See
-    [HtmlMediaElement.videoTracks](https://html.spec.whatwg.org/multipage/media.html#dom-media-videotracks)
+    {{HTMLMediaElement/videoTracks|HTMLMediaElement.videoTracks}}
     for more details.
 
 : added-text-tracks
 :: Add text tracks with the given kinds, labels, and languages. See
-    [HtmlMediaElement.addTextTrack](https://html.spec.whatwg.org/multipage/media.html#dom-media-addtexttrack)
+    {{HTMLMediaElement/addTextTrack()|HTMLMediaElement.addTextTrack()}}
     for more details.  This is optional for the receiver to support and if not
     supported, the receiver will behave as though it were never set.
 
 : changed-text-tracks
 :: Change text tracks by ID.  All other text tracks are left
     unchanged.  Set the mode, add cues, and remove cues by id. See
-    [HtmlMediaElement.textTracks](https://html.spec.whatwg.org/multipage/media.html#dom-media-texttracks)
+    {{HTMLMediaElement/textTracks|HTMLMediaElement.textTracks}}
     for more details.  Note that future specifications or extensions to this
     specifications are expected to add new fields to the [=text-track-cue=]
     (such as text size, alignment, position, etc).  Adding and removing
     cues is optional for the receiver to support and if not supported, the
     receiver will behave as though no cues were added or removed (both adding
     and removing are indicated via the support for "added-cues").  As specified in
-    [HtmlMediaElement.textTracks](https://html.spec.whatwg.org/multipage/media.html#dom-media-texttracks),
+    {{HTMLMediaElement/textTracks|HTMLMediaElement.textTracks}},
     if a cue ID is invalid (removing an un-added ID or adding an ID twice, for example),
     the receiver may reject the text track change.
 
@@ -1364,136 +1372,135 @@ changed.
     for the initial state in the [=remote-playback-start-response=] message.
 
 : source-url
-:: The current [=media resource=] URL. See 
-    [HtmlMediaElement.currentSrc](https://html.spec.whatwg.org/multipage/media.html#dom-media-currentsrc).
+:: The current [=media resource=] URL. See
+    {{HTMLMediaElement/currentSrc|HTMLMediaElement.currentSrc}}.
     Must be present in the initial state in the [=remote-playback-start-response=] message
     so the controller knows what [=media resource=] was selected for playback.
 
 : loading
 :: The state of network activity for loading the [=media resource=]. See
-    [HtmlMediaElement.networkState](https://html.spec.whatwg.org/multipage/media.html#dom-media-networkstate).
-    The default is empty ({{NETWORK_EMPTY}})
+    {{HTMLMediaElement/networkState|HTMLMediaElement.networkState}}.
+    The default is empty ({{NETWORK_EMPTY}}
     for the initial state in the [=remote-playback-start-response=] message.
 
 : loaded
 :: The state of the loaded media (whether enough is loaded to play). See
-    [HtmlMediaElement.readyState](https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate).
-    The default is nothing ({{HAVE_NOTHING}})
+    {{HTMLMediaElement/readyState|HTMLMediaElement.readyState}}.
+    The default is nothing ({{HAVE_NOTHING}}
     for the initial state in the [=remote-playback-start-response=] message.
 
 : error
 :: A major error occurred which prevents the remote playback from continuing. See
-    [HtmlMediaElement.error](https://html.spec.whatwg.org/multipage/media.html#dom-media-error) and
-    [HtmlMediaElement media error codes](https://html.spec.whatwg.org/multipage/media.html#concept-mediaerror-code).
+    {{HTMLMediaElement/error!!attribute|HTMLMediaElement.error}} and
+    [=media error codes=].
     The default is no error
     for the initial state in the [=remote-playback-start-response=] message.
 
 : epoch
 :: The "zero time" of the media timeline. See
-    [HtmlMediaElement's timeline offset](https://html.spec.whatwg.org/multipage/media.html#timeline-offset) and
-    [HtmlMediaElement.getStartDate()](https://html.spec.whatwg.org/multipage/media.html#dom-media-getstartdate).
+    [=timeline offset=] and
+    {{HTMLMediaElement/getStartDate()|HTMLMediaElement.getStartDate()}}.
     The default is an unknown epoch
     for the initial state in the [=remote-playback-start-response=] message.
 
 : duration
 :: The duration of the media timeline. See
-    [HtmlMediaElement.duration](https://html.spec.whatwg.org/multipage/media.html#dom-media-duration).
+    {{HTMLMediaElement/duration|HTMLMediaElement.duration}}.
     The default is an unknown duration
     for the initial state in the [=remote-playback-start-response=] message.
 
 : buffered-time-ranges
 :: The time ranges for which media has been buffered. See
-    [HtmlMediaElement.buffered](https://html.spec.whatwg.org/multipage/media.html#dom-media-buffered).
+    {{HTMLMediaElement/buffered|HTMLMediaElement.buffered}}.
     The default is an empty array
     for the initial state in the [=remote-playback-start-response=] message.
 
 : played-time-ranges
 :: The time ranges reached by the playback position during normal playback. See
-    [HtmlMediaElement.played](https://html.spec.whatwg.org/multipage/media.html#dom-media-played).
+    {{HTMLMediaElement/played|HTMLMediaElement.played}}.
     The default is an empty array
     for the initial state in the [=remote-playback-start-response=] message.
 
 : seekable-time-ranges
 :: The time ranges for which media is seekable by the controller or the receiver. See
-    [HtmlMediaElement.seekable](https://html.spec.whatwg.org/multipage/media.html#dom-media-seekable).
+    {{HTMLMediaElement/seekable|HTMLMediaElement.seekable}}.
     The default is an empty array
     for the initial state in the [=remote-playback-start-response=] message.
 
 : position
 :: The playback position. See
-    [HtmlMediaElement's official playback
-    position](https://html.spec.whatwg.org/multipage/media.html#official-playback-position)
+    [=official playback position=]
     and
-    [HtmlMediaElement.currentTime](https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime).
+    {{HTMLMediaElement/currentTime|HTMLMediaElement.currentTime}}.
     The default is 0
     for the initial state in the [=remote-playback-start-response=] message.
 
 : playbackRate
 :: The current rate of playback on a scale where 1.0 is "normal speed". See
-    [HtmlMediaElement.playbackRate](https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate).
+    {{HTMLMediaElement/playbackRate|HTMLMediaElement.playbackRate}}.
     The default is 1.0
     for the initial state in the [=remote-playback-start-response=] message.
 
 : paused
 :: Whether media is paused or not. See
-    [HtmlMediaElement.paused](https://html.spec.whatwg.org/multipage/media.html#dom-media-paused).
+    {{HTMLMediaElement/paused|HTMLMediaElement.paused}}.
     The default is false
     for the initial state in the [=remote-playback-start-response=] message.
 
 : seeking
 :: Whether the receiver is seeking or not. See
-    [HtmlMediaElement.seeking](https://html.spec.whatwg.org/multipage/media.html#dom-media-seeking).
+    {{HTMLMediaElement/seeking!!attribute|HTMLMediaElement.seeking}}.
     The default is false
     for the initial state in the [=remote-playback-start-response=] message.
 
 : stalled
 :: If true, media is not playing because not enough media is loaded, and false otherwise. See
-    [HtmlMediaElement.stalled](https://html.spec.whatwg.org/multipage/media.html#event-media-stalled).
+    the {{stalled}} event.
     The default is false
     for the initial state in the [=remote-playback-start-response=] message.
 
 : ended
 :: Whether media has reached the end or not. See
-    [HtmlMediaElement.ended](https://html.spec.whatwg.org/multipage/media.html#dom-media-ended).
+    {{HTMLMediaElement/ended!!attribute|HTMLMediaElement.ended}}.
     The default is false
     for the initial state in the [=remote-playback-start-response=] message.
 
 : volume
 :: The current volume of playback on a scale of 0.0 to 1.0. See
-    [HtmlMediaElement.volume](https://html.spec.whatwg.org/multipage/media.html#dom-media-volume).
+    {{HTMLMediaElement/volume|HTMLMediaElement.volume}}.
     The default is 1.0
     for the initial state in the [=remote-playback-start-response=] message.
 
 : muted
 :: True if audio is muted (overriding the volume value) and false otherwise.
     See
-    [HtmlMediaElement.muted](https://html.spec.whatwg.org/multipage/media.html#dom-media-muted).
+    {{HTMLMediaElement/muted|HTMLMediaElement.muted}}.
     The default is false
     for the initial state in the [=remote-playback-start-response=] message.
 
 : resolution
 :: The "intrinsic width" and "intrinsic width" of the video. See
-    [HtmlMediaElement.videoWidth](https://html.spec.whatwg.org/multipage/media.html#dom-media-videowidth)
+    {{HTMLVideoElement/videoWidth|HTMLVideoElement.videoWidth}}
     and
-    [HtmlMediaElement.videoHeight](https://html.spec.whatwg.org/multipage/media.html#dom-media-videoheight).
+    {{HTMLVideoElement/videoHeight|HTMLVideoElement.videoHeight}}.
     The default is unknown
     for the initial state in the [=remote-playback-start-response=] message.
 
 : audio-tracks
 :: The available audio tracks, which can individually enabled or disabled. See
-    [HtmlMediaElement.audioTracks](https://html.spec.whatwg.org/multipage/media.html#dom-media-audiotracks)
+    {{HTMLMediaElement/audioTracks|HTMLMediaElement.audioTracks}}.
     The default is an empty array
     for the initial state in the [=remote-playback-start-response=] message.
 
 : video-tracks
 :: The available video tracks.  Only one may be selected. See
-    [HtmlMediaElement.videoTracks](https://html.spec.whatwg.org/multipage/media.html#dom-media-videotracks)
+    {{HTMLMediaElement/videoTracks|HTMLMediaElement.videoTracks}}.
     The default is an empty array
     for the initial state in the [=remote-playback-start-response=] message.
 
 : text-tracks
 :: The available text tracks, which can be individually shown, hidden, or disabled. See
-    [HtmlMediaElement.textTracks](https://html.spec.whatwg.org/multipage/media.html#dom-media-videotracks).
+    {{HTMLMediaElement/textTracks|HTMLMediaElement.textTracks}}.
     The controller can also add cues to and remove cues from text tracks.
     The default is an empty array
     for the initial state in the [=remote-playback-start-response=] message.


### PR DESCRIPTION
This update converts all explicit references to the HTML spec to Bikeshed's autolinks syntax. To render the name of the interface along with the name of the attribute or method, the "visible text" syntax is used (the text after `|`).

The notions of "media error code", official playback position", "poster frame" and "timeline offset" are not HTMLMediaElement attributes but rather internal HTML concepts whose definitions are not currently exported. Longer term, we should make sure that the HTML spec exports these terms (unless we don't need them anymore).

The text incorrect referred to a `stalled` attribute that does not exist, instead of to the `stalled` event. Text updated accordingly.

This would address #264.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/269.html" title="Last updated on Mar 9, 2021, 11:58 AM UTC (3f99fa2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/269/c1a8b35...3f99fa2.html" title="Last updated on Mar 9, 2021, 11:58 AM UTC (3f99fa2)">Diff</a>