### PR TITLE
Advertise TR URL in the spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4,6 +4,7 @@ Shortname: openscreenprotocol
 Level: 1
 Status: w3c/ED
 ED: https://w3c.github.io/openscreenprotocol/
+TR: https://www.w3.org/TR/openscreenprotocol/
 Canonical URL: ED
 Editor: Mark Foltz, Google, https://github.com/mfoltzgoogle, w3cid 68454
 Repository: w3c/openscreenprotocol


### PR DESCRIPTION
This should add an appropriate "Latest published version:" link to the header now that we published the FPWD.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/272.html" title="Last updated on Mar 18, 2021, 10:46 AM UTC (05eef63)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/272/2c071ca...05eef63.html" title="Last updated on Mar 18, 2021, 10:46 AM UTC (05eef63)">Diff</a>