### PR TITLE
Allow additional discovery mechanisms.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -254,9 +254,14 @@ Non-Functional Requirements {#requirements-non-functional}
 Discovery with mDNS {#discovery}
 ===============================
 
-[=Open Screen Protocol agents=] must discover one another using
-[[RFC6763|DNS-SD]] over [[RFC6762|mDNS]].  To do so, OSP agents must use the
-[=Service Name=] `_openscreen._udp.local`.
+[=Open Screen Protocol agents=] discover one another by advertising and
+listening for information identifying themselves along with an IP service
+endpoint.  Agent advertisment and discovery through [[RFC6763|DNS-SD]] and
+[[RFC6762|mDNS]] is defined by this specification and is mandatory to implement
+by all agents. However, agents are free to implement additional discovery
+mechanisms, such as querying for the same DNS-SD records via unicast DNS.
+
+OSP agents must use the DNS-SD [=Service Name=] `_openscreen._udp.local`.
 
 Issue(107): Define suspend and resume behavior for discovery protocol.
 


### PR DESCRIPTION
Addresses Issue #273: [mDNS] OpenScreenProtocol should not restrict DNS-SD to mDNS

This makes it explicit that while DNS-SD over mDNS is mandatory to implement, the rest of the protocol doesn't rely on mDNS being the only way for agents to discover one another, and they can query DNS-SD over unicast DNS.

Note that we may need to adjust the `at` mechanism intended to restrict connection attempts to intra-LAN scenarios.  Would like to look at that in a separate issue.

