### PR TITLE
Fixes algorithm and signing fields in agent certificate.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -31,8 +31,6 @@ urlPrefix: https://www.w3.org/TR/presentation-api/#dfn-; type: dfn; spec: PRESEN
     text: presentation request url
     text: receiving user agent
     text: creating a receiving browsing context
-urlPrefix: https://www.w3.org/TR/presentation-api/; type: interface; spec: PRESENTATION-API
-    text: PresentationConnection
 urlPrefix: https://w3c.github.io/remote-playback/#dfn-; type: dfn; spec: REMOTE-PLAYBACK
     text: availability sources set
     text: compatible remote playback device
@@ -1449,13 +1447,13 @@ changed.
 : loading
 :: The state of network activity for loading the [=media resource=]. See
     {{HTMLMediaElement/networkState|HTMLMediaElement.networkState}}.
-    The default is empty ({{NETWORK_EMPTY}}
+    The default is empty ({{NETWORK_EMPTY}})
     for the initial state in the [=remote-playback-start-response=] message.
 
 : loaded
 :: The state of the loaded media (whether enough is loaded to play). See
     {{HTMLMediaElement/readyState|HTMLMediaElement.readyState}}.
-    The default is nothing ({{HAVE_NOTHING}}
+    The default is nothing ({{HAVE_NOTHING}})
     for the initial state in the [=remote-playback-start-response=] message.
 
 : error
@@ -1631,10 +1629,10 @@ This is how the [[REMOTE-PLAYBACK|Remote Playback API]] uses the
 messages defined in [[#remote-playback-protocol]]:
 
 When [[REMOTE-PLAYBACK#the-list-of-available-remote-playback-devices|section
-6.2.1.2]] says "This list contains [=remote playback devices=] and is populated
+5.2.1.2]] says "This list contains [=remote playback devices=] and is populated
 based on an implementation specific discovery mechanism" and
 [[REMOTE-PLAYBACK#the-list-of-available-remote-playback-devices|section
-6.2.1.4]] says "Retrieve available remote playback devices (using an
+5.2.1.4]] says "Retrieve available remote playback devices (using an
 implementation specific mechanism)", the user agent may use the mDNS, QUIC,
 [=agent-info-request=], and [=remote-playback-availability-request=] messages
 defined previously in this spec to discover [=receivers=].  The
@@ -1643,7 +1641,7 @@ sources set=].
 
 When
 [[REMOTE-PLAYBACK#establishing-a-connection-with-a-remote-playback-device|section
-6.2.4]] says "Request connection of remote to device. The implementation of this
+5.2.4]] says "Request connection of remote to device. The implementation of this
 step is specific to the user agent." and "Synchronize the current media element
 state with the remote playback state", the controller may send the
 [=remote-playback-start-request=] message to the receiver to start remote
@@ -1654,7 +1652,7 @@ of [[REMOTE-PLAYBACK|Remote Playback API]] may allow for several.
 
 When
 [[REMOTE-PLAYBACK#establishing-a-connection-with-a-remote-playback-device|section
-6.2.4]] says "The mechanism that is used to connect the user agent with the
+5.2.4]] says "The mechanism that is used to connect the user agent with the
 remote playback device and play the remote playback source is an implementation
 choice of the user agent. The connection will likely have to provide a two-way
 messaging abstraction capable of carrying media commands to the remote playback
@@ -1666,8 +1664,8 @@ based on changes to the local media element and receive
 change the local media element based on changes to the remote playback state.
 
 When
-[[REMOTE-PLAYBACK#establishing-a-connection-with-a-remote-playback-device|section
-6.2.7]] says "Request disconnection of remote from the device. The
+[[REMOTE-PLAYBACK#disconnecting-from-a-remote-playback-device|section
+5.2.7]] says "Request disconnection of remote from the device. The
 implementation of this step is specific to the user agent," the controller may
 send the [=remote-playback-termination-request=] message to the receiver.
 

--- a/index.bs
+++ b/index.bs
@@ -55,6 +55,8 @@ url: https://tools.ietf.org/html/rfc8122#section-5; type: dfn; spec: RFC8122; te
 url: https://tools.ietf.org/html/rfc8122#section-5; type: dfn; spec: RFC8122; text: md5
 url: https://tools.ietf.org/html/rfc6381#section-3; type: dfn; spec: RFC6381; text: codecs parameter
 url: https://tools.ietf.org/html/rfc8610#section-3; type: dfn; spec: RFC8610; text: concise data definition language
+url: https://tools.ietf.org/html/rfc5280#section-4.2.1.3; type: dfn; spec: RFC5280; text: digitalSignature
+url: https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.3; type: dfn; spec: RFC8446; text: signature scheme
 </pre>
 
 Introduction {#introduction}
@@ -367,16 +369,43 @@ QUIC connection.
 
 The [=agent certificate=] must have the following characteristics:
 
-* 256-bit, 384-bit, or 521-bit ECDSA public key
-* Self-signed
-* Supporting the at least one of the following signature algorithms:
-    * secp256r1_sha256
-    * secp384r1_sha384
-    * secp521r1_sha512
-* Valid for signing
+* 256-bit, 384-bit, or 521-bit ECDSA public key.
+* Self-signed.
+* Supporting the at least one of the [=certificate algorithms=] listed below.
+    * The `AlgorithmIdentifiers` are defined in [[!RFC5480]].
+* Valid for signing.
+
+<table id="algorithms" class="data">
+<caption><dfn lt="certificate algorithms">Agent Certificate Algorithms</dfn></caption>
+<thead>
+<tr>
+  <th>TLS 1.3 [=Signature Scheme=]</th>
+  <th>Public Key `AlgorithmIdentifier`</th>
+  <th>Signature `AlgorithmIdentifier`</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>`secp256r1_sha256`</td>
+  <td>`301306072a8648ce3d020106082a8648ce3d030107`</td>
+  <td>`300a06082a8648ce3d040302`</td>
+</tr>
+<tr>
+  <td>`secp384r1_sha384`</td>
+  <td>`301006072a8648ce3d020106052b81040022`</td>
+  <td>`300a06082a8648ce3d040303`</td>
+</tr>
+<tr>
+  <td>`secp521r1_sha512`</td>
+  <td>TBD</td>
+  <td>TBD</td>
+</tr>
+</tbody>
+</table>
 
 The following X.509 v3 fields are to be set as follows:
 
+<div class="assertion">
 <table>
 <thead>
  <th>Field</th>
@@ -392,8 +421,12 @@ The following X.509 v3 fields are to be set as follows:
    <td>`<fp>`</td>
  </tr>
  <tr>
-   <td>Signature Algorithm ID</td>
-   <td>One of the values listed above.</td>
+   <td>Public Key `AlgorithmIdentifier`</td>
+   <td>One of the supported  [=certificate algorithms=].</td>
+ </tr>
+ <tr>
+   <td>Signature `AlgorithmIdentifier`</td>
+   <td>One of the supported  [=certificate algorithms=].</td>
  </tr>
  <tr>
    <td>Issuer Name</td>
@@ -416,10 +449,11 @@ The following X.509 v3 fields are to be set as follows:
  </tr>
  <tr>
    <td>Certificate Key usage</td>
-   <td>Signing</td>
+   <td>[=digitalSignature=]</td>
  </tr>
 </tbody>
 </table>
+</div>
 
 Mandatory fields not mentioned above should be set according to [[!RFC5280]].
 

--- a/index.bs
+++ b/index.bs
@@ -1056,10 +1056,10 @@ Representation Of Time {#time-representation}
 
 The [[#remote-playback-protocol]] and the [[#streaming-protocol]] represent
 points of time and durations in terms of a [=time scale=].  A <dfn>time
-scale</dfn> is a common denominator for time values that allows values which
-work on different time scales to be expressed as rational numbers without loss
-of precision.  The [=time scale=] is represented in hertz, such as 90000 for
-90000 Hz, a common time scale for video.
+scale</dfn> is a common denominator for time values that allows values to be
+expressed as rational numbers without loss of precision.  The [=time scale=] is
+represented in hertz, such as 90000 for 90000 Hz, a common time scale for
+video.
 
 Remote Playback Protocol {#remote-playback-protocol}
 ========================

--- a/index.bs
+++ b/index.bs
@@ -30,7 +30,6 @@ urlPrefix: https://www.w3.org/TR/presentation-api/#dfn-; type: dfn; spec: PRESEN
     text: presentation id
     text: presentation request url
     text: receiving user agent
-    text: creating a receiving browsing context
 urlPrefix: https://w3c.github.io/remote-playback/#dfn-; type: dfn; spec: REMOTE-PLAYBACK
     text: availability sources set
     text: compatible remote playback device

--- a/index.bs
+++ b/index.bs
@@ -395,11 +395,6 @@ The [=agent certificate=] must have the following characteristics:
   <td>`301006072a8648ce3d020106052b81040022`</td>
   <td>`300a06082a8648ce3d040303`</td>
 </tr>
-<tr>
-  <td>`secp521r1_sha512`</td>
-  <td>TBD</td>
-  <td>TBD</td>
-</tr>
 </tbody>
 </table>
 

--- a/index.bs
+++ b/index.bs
@@ -31,7 +31,7 @@ urlPrefix: https://www.w3.org/TR/presentation-api/#dfn-; type: dfn; spec: PRESEN
     text: presentation request url
     text: receiving user agent
     text: creating a receiving browsing context
-urlPrefix: https://w3c.github.io/presentation-api/; type: interface; spec: PRESENTATION-API
+urlPrefix: https://www.w3.org/TR/presentation-api/; type: interface; spec: PRESENTATION-API
     text: PresentationConnection
 urlPrefix: https://w3c.github.io/remote-playback/#dfn-; type: dfn; spec: REMOTE-PLAYBACK
     text: availability sources set

--- a/index.bs
+++ b/index.bs
@@ -833,7 +833,7 @@ values:
 : headers
 :: headers that the receiver should use to fetch the presentation URL.  For example,
     [[PRESENTATION-API#creating-a-receiving-browsing-context|section 6.6.1]] of
-    the Presentation API says that the Accept-Language header should be
+    the Presentation API says that the HTTP `Accept-Language` header should be
     provided.
 
 The presentation ID must follow the restrictions defined by

--- a/index.bs
+++ b/index.bs
@@ -374,6 +374,7 @@ The [=agent certificate=] must have the following characteristics:
 * Supporting at least one of the [=certificate algorithms=] listed below.
     * The `AlgorithmIdentifiers` are defined in [[!RFC5480]] (for public keys) and
         [[!RFC5758]] (for signature schemes).
+    * [[!X690]] specifies the Distinguished Encoding Rules (DER) representation used to encode the identifiers.
 * Valid for signing.
 
 <table id="algorithms" class="data">

--- a/index.bs
+++ b/index.bs
@@ -409,8 +409,25 @@ The [=agent certificate=] must have the following characteristics:
 </tr>
 <tr>
   <td>`secp384r1_sha384`</td>
-  <td>`301006072a8648ce3d020106052b81040022`</td>
-  <td>`300a06082a8648ce3d040303`</td>
+  <td>`secp384r1`
+   <p>
+    Object Identifiers:
+    <ol>
+      <li>`1.2.840.10045.2.1` (ECC)</li>
+      <li>`1.3.132.0.34` (ECDSA P384)</li>
+    </ol> 
+    DER representation: `301006072a8648ce3d020106052b81040022`
+  </p>
+  </td>
+  <td>`ecdsa-with-SHA384`
+    <p>
+      Object identifier:
+      <ol>
+        <li>`1.2.840.10045.4.3.3`</li>
+      </ol>
+      DER representation: `300a06082a8648ce3d040303`
+    </p>
+  </td>
 </tr>
 </tbody>
 </table>

--- a/index.bs
+++ b/index.bs
@@ -1765,7 +1765,7 @@ following additional fields:
 
     The `transfer-function` field must be a valid
     [[MEDIA-CAPABILITIES#transferfunction|TransferFunction]]
-    and the `hdr-metadata` must be a valid
+    and the `hdr-metadata` field must be a valid
     [[MEDIA-CAPABILITIES#hdrmetadatatype|HdrMetadataType]], both defined in the
     [[!MEDIA-CAPABILITIES|Media Capabilities]] API.
 
@@ -1774,6 +1774,7 @@ following additional fields:
     without any associated metadata.  (This is the case, for example, with the
     "hlg" `transfer-function`.)
 
+    The media receiver should ignore duplicate entries in `hdr-formats.`
     If no `hdr-formats` are listed, then the media reciever cannot decode any
     HDR formats.
 

--- a/index.bs
+++ b/index.bs
@@ -2604,7 +2604,7 @@ authentication:
 
 The active attacker may also attempt to disrupt data exchanged over the QUIC
 connection by injecting or modifying traffic.  These attacks should be mitigated
-by a correct implementation of TLS 1.3.  See Appendix E of [[RFC846]] for a
+by a correct implementation of TLS 1.3.  See Appendix E of [[RFC8446]] for a
 detailed security analysis of the TLS 1.3 protocol.
 
 ### Remote active network attackers ### {#remote-active-mitigations}

--- a/index.bs
+++ b/index.bs
@@ -1758,18 +1758,25 @@ following additional fields:
     in the [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is
     a list with the single entry "srgb".
 
-: transfer-functions (optional)
-:: An optional field indicating what HDR transfer functions can be decoded and rendered
-    by the media receiver.  Valid values correspond to
-    [[MEDIA-CAPABILITIES#transferfunction|TransferFunction]] in the
-    [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is a list with the
-    single entry "srgb".
+: hdr-formats (optional)
+:: An optional field indicating what HDR transfer functions and metadata formats
+    can be decoded and rendered by the media receiver.  Each `video-hdr-format`
+    consists of two fields, `transfer-function` and `hdr-metadata`.
 
-: hdr-metadata (optional)
-:: An optional field indicating what HDR metadata types can be decoded and rendered by
-    by the media receiver.  Valid values correspond to
-    [[MEDIA-CAPABILITIES#hdrmetadatatype|HdrMetadataType]] in the
-    [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is an empty list.
+    The `transfer-function` field must be a valid
+    [[MEDIA-CAPABILITIES#transferfunction|TransferFunction]]
+    and the `hdr-metadata` must be a valid
+    [[MEDIA-CAPABILITIES#hdrmetadatatype|HdrMetadataType]], both defined in the
+    [[!MEDIA-CAPABILITIES|Media Capabilities]] API.
+
+    If a `video-hdr-format` is provided with a `transfer-function` but no
+    `hdr-metadata`, then the media receiver can render the `transfer-function`
+    without any associated metadata.  (This is the case, for example, with the
+    "hlg" `transfer-function`.)
+
+    If no `hdr-formats` are listed, then the media reciever cannot decode any
+    HDR formats.
+
 
 : native-resolutions (optional)
 :: An optional field indicating what video-resolutions the media receiver supports and

--- a/index.bs
+++ b/index.bs
@@ -1742,14 +1742,25 @@ following additional fields:
     display could return this value as 1.6 to indicate its preferred content
     scaling. Default is none.
 
-Issue(194): Expose capabilities for decoding HDR transfer functions and metadata formats.
-
 : color-gamuts (optional)
 :: An optional field indicating what color spaces can be decoded and rendered by
     the media receiver.  The media sender may use these values to determine how
     to encode video. Valid values correspond to [[MEDIA-CAPABILITIES#colorgamut|ColorGamut]]
     in the [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is
     a list with the single entry "srgb".
+
+: transfer-functions (optional)
+:: An optional field indicating what HDR transfer functions can be decoded and rendered
+    by the media receiver.  Valid values correspond to
+    [[MEDIA-CAPABILITIES#transferfunction|TransferFunction]] in the
+    [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is a list with the
+    single entry "srgb".
+
+: hdr-metadata (optional)
+:: An optional field indicating what HDR metadata types can be decoded and rendered by
+    by the media receiver.  Valid values correspond to
+    [[MEDIA-CAPABILITIES#hdrmetadatatype|HdrMetadataType]] in the
+    [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is an empty list.
 
 : native-resolutions (optional)
 :: An optional field indicating what video-resolutions the media receiver supports and

--- a/index.bs
+++ b/index.bs
@@ -369,7 +369,7 @@ QUIC connection.
 
 The [=agent certificate=] must have the following characteristics:
 
-* 256-bit, 384-bit, or 521-bit ECDSA public key.
+* 256-bit or 384-bit ECDSA public key.
 * Self-signed.
 * Supporting at least one of the [=certificate algorithms=] listed below.
     * The `AlgorithmIdentifiers` are defined in [[!RFC5480]] (for public keys) and

--- a/index.bs
+++ b/index.bs
@@ -1703,14 +1703,17 @@ The format type is used as the basis for audio and video capabilities.
 Formats are composed of the following fields:
 
 : name (required)
-:: The name of the codec.   This must be a single-codec RFC 6381 [=codecs parameter=].
-
-Issue(233): Use the same codec names as the media APIs.
+:: A fully qualified codec string listed in the [[WEBCODECS-CODEC-REGISTRY]] and further
+     specified by the codec-specific registrations referenced in that registry.
 
 : parameters (required)
 :: A list of (key, value) parameters that can be used to describe
     properties of a specific format, and not shared by other formats
     of that type (audio, video, etc.).
+
+For `name`, Open Screen agents may also accept a single-codec [=codec
+parameter=] as described in [[!RFC6381]] for codecs not listed in the
+[[WEBCODECS-CODEC-REGISTRY]].
 
 Issue(266): Specify where codec-specific parameters are defined or drop them.
 

--- a/index.bs
+++ b/index.bs
@@ -371,7 +371,7 @@ The [=agent certificate=] must have the following characteristics:
 
 * 256-bit, 384-bit, or 521-bit ECDSA public key.
 * Self-signed.
-* Supporting the at least one of the [=certificate algorithms=] listed below.
+* Supporting at least one of the [=certificate algorithms=] listed below.
     * The `AlgorithmIdentifiers` are defined in [[!RFC5480]].
 * Valid for signing.
 

--- a/index.bs
+++ b/index.bs
@@ -1051,6 +1051,16 @@ must send a [=presentation-connection-open-response=] message and
 [=presentation-change-event=] messages when required.
 
 
+Representation Of Time {#time-representation}
+======================
+
+The [[#remote-playback-protocol]] and the [[#streaming-protocol]] represent
+points of time and durations in terms of a [=time scale=].  A <dfn>time
+scale</dfn> is a common denominator for time values that allows values which
+work on different time scales to be expressed as rational numbers without loss
+of precision.  The [=time scale=] is represented in hertz, such as 90000 for
+90000 Hz, a common time scale for video.
+
 Remote Playback Protocol {#remote-playback-protocol}
 ========================
 
@@ -1565,9 +1575,7 @@ changed.
 
 All times, time ranges, and durations (such as position, duration, and
 seekable-time-ranges) used above use a common [=media-time=] value (see Appendix A)
-which includes a time scale.  This allows time values which work on different
-time scales to be expressed without loss of precision.  The scale is represented
-in hertz, such as 90000 for 90000 Hz, a common time scale for video.
+which includes a [=time scale=]. 
 
 <div class="note">
 <table>
@@ -1851,7 +1859,7 @@ Each audio encoding offered defines the following fields:
     RFC 6381 [=codecs parameter=].
 
 : time-scale
-:: The time scale used by all audio frames.  This allows senders to
+:: The [=time scale=] used by all audio frames.  This allows senders to
     make audio-frame messages smaller by not including the time scale
     in each one.
 
@@ -1872,7 +1880,7 @@ Each video encoding offered defines the following fields:
 :: The name of the codec used by the encoding.
 
 : time-scale
-:: The time scale used by all video frames.  This allows senders to
+:: The [=time scale=] used by all video frames.  This allows senders to
     make video-frame messages smaller by not including the time scale
     in each one.
 
@@ -1898,7 +1906,7 @@ Each data encoding offered defines the following fields:
 :: The name of the data type used by the encoding.
 
 : time-scale
-:: The time scale used by all data frames.  This allows senders to
+:: The [=time scale=] used by all data frames.  This allows senders to
     make data-frame messages smaller by not including the time scale
     in each one.
 
@@ -1978,21 +1986,21 @@ separate QUIC streams.
 :: Identifies the media encoding to which this audio frame belongs.  This can be
     used to reference fields of the encoding (from the
     [=audio-encoding-offer=] message) such as the codec, codec properties,
-    time scale (aka clock rate), and default duration.
+    [=time scale=], and default duration.
     Referencing fields of the encoding through the encoding id
     helps to avoid sending duplicate information in every frame.
 
 : start-time
 :: Identifies the beginning of the time range of the audio frame. The
     end time can be inferred from the start time and duration. The
-    time scale is equal to the value in the `time-scale` field of the
+    [=time scale=] is equal to the value in the `time-scale` field of the
     [=audio-encoding-offer=] message referenced by the `encoding-id`.
 
 : duration
 :: If present, the duration of the audio frame. If not present, the
     duration is equal to the `default-duration` field of the
     [=audio-encoding-offer=] message referenced by the `encoding-id`.
-    The time scale is equal to the value in the `time-scale` field of
+    The [=time scale=] is equal to the value in the `time-scale` field of
     the [=audio-encoding-offer=] message referenced by the `encoding-id`.
 
 : sync-time
@@ -2025,7 +2033,7 @@ ending at the last dependent frame.
 : encoding-id
 :: Identifies the media encoding to which this video frame belongs.
     This can be used to reference fields of the encoding such as the
-    codec, codec properties, time scale, and default rotation.
+    codec, codec properties, [=time scale=], and default rotation.
     Referencing fields of the encoding through the encoding id helps
     to avoid sending duplicate information in every frame.
 
@@ -2044,12 +2052,12 @@ ending at the last dependent frame.
 : start-time
 :: Identifies the beginning of the time range of the video frame.  The
     end time can be inferred from the start time and duration. The
-    time scale is equal to the value in the `time-scale` field of the
+    [=time scale=] is equal to the value in the `time-scale` field of the
     [=video-encoding-offer=] message referenced by the `encoding-id`.
 
 : duration
 :: If present, the duration of the video frame. If not present, that
-    means duration is unknown.  The time scale is equal to the value
+    means duration is unknown.  The [=time scale=] is equal to the value
     in the `time-scale` field of the [=video-encoding-offer=] message
     referenced by the `encoding-id`.
 
@@ -2085,7 +2093,7 @@ that makes sense for a specific type of data.
 : encoding-id
 :: Identifies the data encoding to which this data frame belongs.  This can be
     used to reference fields of the encoding such as the type of data and
-    time scale.  Referencing fields of the encoding through the encoding id
+    [=time scale=].  Referencing fields of the encoding through the encoding id
     helps to avoid sending duplicate information in every frame.
 
 : sequence-number
@@ -2096,14 +2104,14 @@ that makes sense for a specific type of data.
 : start-time
 :: Identifies the beginning of the time range of the data frame.  The
     end time can be inferred from the start time and duration.  The
-    time scale is equal to the value in the `time-scale` field of the
+    [=time scale=] is equal to the value in the `time-scale` field of the
     [=data-encoding-offer=] message referenced by the `encoding-id`.
 
 : duration
 :: If present, the duration of the data frame. If not present, the
     duration is equal to the `default-duration` field of the
     [=data-encoding-offer=] message referenced by the `encoding-id`.
-    The time scale is equal to the value in the `time-scale` field of
+    The [=time scale=] is equal to the value in the `time-scale` field of
     the [=data-encoding-offer=] message referenced by the `encoding-id`.
 
 : sync-time

--- a/index.bs
+++ b/index.bs
@@ -372,7 +372,8 @@ The [=agent certificate=] must have the following characteristics:
 * 256-bit, 384-bit, or 521-bit ECDSA public key.
 * Self-signed.
 * Supporting at least one of the [=certificate algorithms=] listed below.
-    * The `AlgorithmIdentifiers` are defined in [[!RFC5480]].
+    * The `AlgorithmIdentifiers` are defined in [[!RFC5480]] (for public keys) and
+      [[!RFC5758]] (for signature schemes).
 * Valid for signing.
 
 <table id="algorithms" class="data">
@@ -387,8 +388,25 @@ The [=agent certificate=] must have the following characteristics:
 <tbody>
 <tr>
   <td>`secp256r1_sha256`</td>
-  <td>`301306072a8648ce3d020106082a8648ce3d030107`</td>
-  <td>`300a06082a8648ce3d040302`</td>
+  <td>`secp256r1`
+     <p>
+      Object Identifiers:
+      <ol>
+        <li>`1.2.840.10045.2.1` (ECC)</li>
+        <li>`1.2.840.10045.3.1.7` (ECDSA P256)</li>
+      </ol>
+      DER representation: `301306072a8648ce3d020106082a8648ce3d030107`
+      </p>
+  </td>
+  <td>`ecdsaWithSha256`
+    <p>
+      Object identifier:
+      <ol>
+        <li>`1.2.840.10045.4.3.2`</li>
+      </ol>
+      DER representation: `300a06082a8648ce3d040302`
+    </p>
+  </td>
 </tr>
 <tr>
   <td>`secp384r1_sha384`</td>

--- a/index.bs
+++ b/index.bs
@@ -399,7 +399,7 @@ The [=agent certificate=] must have the following characteristics:
       DER representation: `301306072a8648ce3d020106082a8648ce3d030107`
       </p>
   </td>
-  <td>`ecdsaWithSha256`
+  <td>`ecdsa-with-SHA256`
     <p>
       Object identifier:
       <ol>

--- a/index.bs
+++ b/index.bs
@@ -23,13 +23,14 @@ urlPrefix: https://html.spec.whatwg.org/multipage/media.html#; type: dfn; spec: 
     text: official playback position
     text: poster frame
     text: timeline offset
-urlPrefix: https://w3c.github.io/presentation-api/#dfn-; type: dfn; spec: PRESENTATION-API
+urlPrefix: https://www.w3.org/TR/presentation-api/#dfn-; type: dfn; spec: PRESENTATION-API
     text: available presentation display
     text: controlling user agent
     text: presentation
     text: presentation id
     text: presentation request url
     text: receiving user agent
+    text: creating a receiving browsing context
 urlPrefix: https://w3c.github.io/presentation-api/; type: interface; spec: PRESENTATION-API
     text: PresentationConnection
 urlPrefix: https://w3c.github.io/remote-playback/#dfn-; type: dfn; spec: REMOTE-PLAYBACK
@@ -831,7 +832,7 @@ values:
 
 : headers
 :: headers that the receiver should use to fetch the presentation URL.  For example,
-    [[PRESENTATION-API#establishing-a-presentation-connection|section 6.6.1]] of
+    [[PRESENTATION-API#creating-a-receiving-browsing-context|section 6.6.1]] of
     the Presentation API says that the Accept-Language header should be
     provided.
 

--- a/index.bs
+++ b/index.bs
@@ -373,7 +373,7 @@ The [=agent certificate=] must have the following characteristics:
 * Self-signed.
 * Supporting at least one of the [=certificate algorithms=] listed below.
     * The `AlgorithmIdentifiers` are defined in [[!RFC5480]] (for public keys) and
-      [[!RFC5758]] (for signature schemes).
+        [[!RFC5758]] (for signature schemes).
 * Valid for signing.
 
 <table id="algorithms" class="data">

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -553,6 +553,11 @@ video-resolution = {
   1: uint ; width
 }
 
+video-hdr-format = {
+  0: transfer-function ; string
+  1: ? hdr-metadata ; string
+}
+
 receive-video-capability = {
   0: format ; codec
   ? 1: video-resolution ; max-resolution
@@ -561,11 +566,10 @@ receive-video-capability = {
   ? 4: uint ; min-bit-rate
   ? 5: ratio ; aspect-ratio
   ? 6: [* string] ; color-gamuts
-  ? 7: [* string] ; transfer-functions
-  ? 8: [* string] ; hdr-metadata
-  ? 9: [* video-resolution] ; native-resolutions
-  ? 10: bool ; supports-scaling
-  ? 11: bool ; supports-rotation
+  ? 7: [* video-hdr-format] ; hdr-formats
+  ? 8: [* video-resolution] ; native-resolutions
+  ? 9: bool ; supports-scaling
+  ? 10: bool ; supports-rotation
 }
 
 receive-data-capability = {

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -561,9 +561,11 @@ receive-video-capability = {
   ? 4: uint ; min-bit-rate
   ? 5: ratio ; aspect-ratio
   ? 6: [* string] ; color-gamuts
-  ? 7: [* video-resolution] ; native-resolutions
-  ? 8: bool ; supports-scaling
-  ? 9: bool ; supports-rotation
+  ? 7: [* string] ; transfer-functions
+  ? 8: [* string] ; hdr-metadata
+  ? 9: [* video-resolution] ; native-resolutions
+  ? 10: bool ; supports-scaling
+  ? 11: bool ; supports-rotation
 }
 
 receive-data-capability = {

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -566,10 +566,10 @@ receive-video-capability = {
   ? 4: uint ; min-bit-rate
   ? 5: ratio ; aspect-ratio
   ? 6: [* string] ; color-gamuts
-  ? 7: [* video-hdr-format] ; hdr-formats
-  ? 8: [* video-resolution] ; native-resolutions
-  ? 9: bool ; supports-scaling
-  ? 10: bool ; supports-rotation
+  ? 7: [* video-resolution] ; native-resolutions
+  ? 8: bool ; supports-scaling
+  ? 9: bool ; supports-rotation
+  ? 10: [* video-hdr-format] ; hdr-formats
 }
 
 receive-data-capability = {


### PR DESCRIPTION
Addresses:
  *  Issue #279: The keyUsage name is digitalSignature, not signing
  *  Issue #280: Clarify the supported signature algorithms for certificates

For the first item, it explicitly references the `keyUsage` bit for `digitalSigning`.

For the second item, I added a table that matches the TLS signature_scheme values to the `AlgorithmIdentifier` values that should be used in the certificate.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/288.html" title="Last updated on Oct 27, 2021, 6:25 AM UTC (f96a9d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/288/7305111...f96a9d5.html" title="Last updated on Oct 27, 2021, 6:25 AM UTC (f96a9d5)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/288.html" title="Last updated on Nov 10, 2022, 1:31 AM UTC (d62bf1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/288/246bc07...d62bf1b.html" title="Last updated on Nov 10, 2022, 1:31 AM UTC (d62bf1b)">Diff</a>