### PR TITLE
Fix a couple of typos: no "format" field and audio/video mix-up

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1942,7 +1942,7 @@ separate QUIC streams.
 
 : payload
 :: The encoded audio.  The codec and codec parameters are equal to the
-    `format` field of the [=audio-encoding-offer=] message referenced by
+    `codec-name` field of the [=audio-encoding-offer=] message referenced by
     the `encoding-id`
 
 Video {#streaming-video}
@@ -2006,8 +2006,8 @@ ending at the last dependent frame.
 
 : payload
 :: The encoded video frame (encoded image).  The codec and codec
-     parameters are are equal to the `format` field of the
-     [=audio-encoding-offer=] message referenced by the `encoding-id`.
+     parameters are equal to the `codec-name` field of the
+     [=video-encoding-offer=] message referenced by the `encoding-id`.
 
 Data {#streaming-data}
 ------------------------------------

--- a/index.bs
+++ b/index.bs
@@ -1943,7 +1943,7 @@ separate QUIC streams.
 : payload
 :: The encoded audio.  The codec and codec parameters are equal to the
     `codec-name` field of the [=audio-encoding-offer=] message referenced by
-    the `encoding-id`
+    the `encoding-id`.
 
 Video {#streaming-video}
 --------------------------------------------

--- a/index.bs
+++ b/index.bs
@@ -2051,7 +2051,7 @@ that makes sense for a specific type of data.
     timelines.
 
 : payload
-:: The data.  The data type is equal to the `data-type` field of the
+:: The data.  The data type is equal to the `data-type-name` field of the
     the [=data-encoding-offer=] message referenced by the `encoding-id`.
 
 Feedback {#streaming-feedback}


### PR DESCRIPTION
The spec incorrectly referenced the `audio-encoding-offer` message from within the description of the video payload property.

Also, the description of the payload property mentioned the `format` field of `audio-encoding-offer` and `video-encoding-offer` messages, but these fields do not exist. This update references the `codec-name` field instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/openscreenprotocol/pull/289.html" title="Last updated on Jan 20, 2022, 11:32 PM UTC (372ed4e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/289/e63d958...tidoust:372ed4e.html" title="Last updated on Jan 20, 2022, 11:32 PM UTC (372ed4e)">Diff</a>