### PR TITLE
Enable auto-publication of WD to /TR

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -46,3 +46,7 @@ jobs:
         uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-secondscreen/2022Apr/0007.html
+          W3C_BUILD_OVERRIDE: |
+            status: WD


### PR DESCRIPTION
The spec-prod action was already used to deploy the generated spec to the `gh-pages` branch. This update tells the action to also deploy the spec as Working Draft to /TR.

The `ECHIDNA_TOKEN` token was added as secret in the repository settings.