### PR TITLE
Update pygmentize_dir.py for Pygments 2.13.0

### DIFF
--- a/scripts/pygmentize_dir.py
+++ b/scripts/pygmentize_dir.py
@@ -15,7 +15,7 @@ OUTPUT_EXTENSION = ".html"
 CDDL_TYPE_KEY_RE = re.compile(r'(<span class="nc">)([A-Za-z0-9-]+)');
 
 class OSPHtmlFormatter(HtmlFormatter):
-  def wrap(self, source, outfile):
+  def wrap(self, source):
     return self._wrap_code(source)
 
   def _wrap_code(self, source):


### PR DESCRIPTION
Pygments 2.12.0 removed the `outfile` argument from HtmlFormatter.wrap.