### PR TITLE
Remove P-521 curve from agent certificate requirements

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -367,12 +367,11 @@ QUIC connection.
 
 The [=agent certificate=] must have the following characteristics:
 
-* 256-bit, 384-bit, or 521-bit ECDSA public key
+* 256-bit or 384-bit ECDSA public key
 * Self-signed
 * Supporting the at least one of the following signature algorithms:
     * secp256r1_sha256
     * secp384r1_sha384
-    * secp521r1_sha512
 * Valid for signing
 
 The following X.509 v3 fields are to be set as follows:


### PR DESCRIPTION
Addresses Issue #277: Consider removing support for P-521

P-521 is a 521-bit elliptic curve that can be used to generate ECDSA certificates.  Although it's supported in TLS 1.3, it is not widely used in practice.

See [this thread on mozilla.dev.security.policy](https://groups.google.com/g/mozilla.dev.security.policy/c/7O34-DmZeC8?pli=1) for some discussion of the issues with P-521.  In short it offers little incremental security benefits over P-384, and ECC implementations are likely not very optimized.

So we're not going to make it an option for OSP agent certificates, so implementations don't need to support it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/295.html" title="Last updated on Sep 8, 2022, 8:00 PM UTC (bcc0bc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/295/e8e728c...bcc0bc0.html" title="Last updated on Sep 8, 2022, 8:00 PM UTC (bcc0bc0)">Diff</a>