### PR TITLE
Simplify TLS requirements so we don't have to recommend algorithms.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -390,11 +390,22 @@ The following X.509 v3 fields are to be set as follows:
  </tr>
  <tr>
    <td>Public Key `AlgorithmIdentifier`</td>
-   <td>One of the supported  [=certificate algorithms=].</td>
+   <td>OID:
+      <ol>
+        <li>`1.2.840.10045.2.1` (ECC)</li>
+        <li>`1.2.840.10045.3.1.7` (ECDSA P256)</li>
+      </ol>
+      DER representation: `301306072a8648ce3d020106082a8648ce3d030107`
+   </td>
  </tr>
  <tr>
    <td>Signature `AlgorithmIdentifier`</td>
-   <td>One of the supported  [=certificate algorithms=].</td>
+   <td>OID:
+      <ol>
+        <li>`1.2.840.10045.4.3.2`</li>
+      </ol>
+   </td>
+   DER representation: `300a06082a8648ce3d040302`
  </tr>
  <tr>
    <td>Issuer Name</td>

--- a/index.bs
+++ b/index.bs
@@ -368,7 +368,11 @@ The [=agent certificate=] must have the following characteristics:
 
 * 256-bit ECDSA public key.
 * Self-signed.
-* Support the `secp256r1_sha256` signature algorithm.
+* Support the `ecdsa_secp256r1_sha256` [=signature scheme=] as defined in TLS 1.3.
+     * The `AlgorithmIdentifier` values are as defined in [[!RFC5480]] (for public
+        keys) and [[!RFC5758]] (for signature schemes).
+     * [[!X690]] specifies the Distinguished Encoding Rules (DER) representation
+        used to encode the identifiers.
 * Valid for signing.
 
 The following X.509 v3 fields are to be set as follows:
@@ -390,22 +394,22 @@ The following X.509 v3 fields are to be set as follows:
  </tr>
  <tr>
    <td>Public Key `AlgorithmIdentifier`</td>
-   <td>OID:
-      <ol>
-        <li>`1.2.840.10045.2.1` (ECC)</li>
-        <li>`1.2.840.10045.3.1.7` (ECDSA P256)</li>
+   <td>
+      <ul>
+        <li>ECC OID: `1.2.840.10045.2.1`</li>
+        <li>ECDSA 256 OID: `1.2.840.10045.3.1.7`</li>
+        <li>DER representation: `301306072a8648ce3d020106082a8648ce3d030107`</li>
       </ol>
-      DER representation: `301306072a8648ce3d020106082a8648ce3d030107`
    </td>
  </tr>
  <tr>
    <td>Signature `AlgorithmIdentifier`</td>
-   <td>OID:
-      <ol>
-        <li>`1.2.840.10045.4.3.2`</li>
-      </ol>
+   <td>
+     <ul>
+       <li>OID: `1.2.840.10045.4.3.2`</li>
+       <li>DER representation: `300a06082a8648ce3d040302`</li>
+     </ul>
    </td>
-   DER representation: `300a06082a8648ce3d040302`
  </tr>
  <tr>
    <td>Issuer Name</td>

--- a/index.bs
+++ b/index.bs
@@ -353,9 +353,6 @@ An OSP Agent must not send TLS early data.
 
 Issue(228): Register ALPN with IANA.
 
-Issue(218): Make recommendations for cipher and signature algorithm preference
-list based on hardware characteristics of agents.
-
 Agent Certificates {#certificates}
 ----------------------------------
 

--- a/index.bs
+++ b/index.bs
@@ -364,13 +364,10 @@ QUIC connection.
 
 The [=agent certificate=] must have the following characteristics:
 
-* 256-bit, 384-bit, or 521-bit ECDSA public key
-* Self-signed
-* Supporting the at least one of the following signature algorithms:
-    * secp256r1_sha256
-    * secp384r1_sha384
-    * secp521r1_sha512
-* Valid for signing
+* 256-bit ECDSA public key.
+* Self-signed.
+* Support the `secp256r1_sha256` signature algorithm.
+* Valid for signing.
 
 The following X.509 v3 fields are to be set as follows:
 


### PR DESCRIPTION
This PR addresses #218: Adjust cipher and signature algorithm preference list for hardware.

The required-to-implement algorithms in TLS 1.3 are suitable for the vast majority of hardware released in the past 10 years and should be forward compatible as well.

The spec can simply require TLS 1.3 and align the agent certificate definition with TLS 1.3 by requiring a 256-bit ECDSA public key.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/297.html" title="Last updated on Oct 16, 2023, 5:23 PM UTC (e4b8f5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/297/ee2b93f...e4b8f5c.html" title="Last updated on Oct 16, 2023, 5:23 PM UTC (e4b8f5c)">Diff</a>