### PR TITLE
Reference WebCodecs registry for codec names.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1647,14 +1647,17 @@ The format type is used as the basis for audio and video capabilities.
 Formats are composed of the following fields:
 
 : name (required)
-:: The name of the codec.   This must be a single-codec RFC 6381 [=codecs parameter=].
-
-Issue(233): Use the same codec names as the media APIs.
+:: A fully qualified codec string listed in the [[WEBCODECS-CODEC-REGISTRY]] and further
+     specified by the codec-specific registrations referenced in that registry.
 
 : parameters (required)
 :: A list of (key, value) parameters that can be used to describe
     properties of a specific format, and not shared by other formats
     of that type (audio, video, etc.).
+
+For `name`, Open Screen agents may also accept a single-codec [=codec
+parameter=] as described in [[!RFC6381]] for codecs not listed in the
+[[WEBCODECS-CODEC-REGISTRY]].
 
 Issue(266): Specify where codec-specific parameters are defined or drop them.
 


### PR DESCRIPTION
Addresses Issue #233: Use the same codec names as the media APIs.

Per the discussion in https://www.w3.org/2022/06/08-webscreens-minutes.html#t08, this updates the spec to refer explicitly to the WebCodecs registry to define codec strings for codecs in that registry.

It adds fallback language for additional codecs not defined in that registry, but if it is not sufficient to define the strings for additional codecs I would prefer to just remove the fallback language from this PR and address that separately.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/299.html" title="Last updated on Sep 9, 2022, 10:23 PM UTC (e104c11)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/299/e8e728c...e104c11.html" title="Last updated on Sep 9, 2022, 10:23 PM UTC (e104c11)">Diff</a>