### PR TITLE
Add transfer-functions and hdr-metadata to video-capabilities.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1716,7 +1716,7 @@ following additional fields:
 
     The `transfer-function` field must be a valid
     [[MEDIA-CAPABILITIES#transferfunction|TransferFunction]]
-    and the `hdr-metadata` must be a valid
+    and the `hdr-metadata` field must be a valid
     [[MEDIA-CAPABILITIES#hdrmetadatatype|HdrMetadataType]], both defined in the
     [[!MEDIA-CAPABILITIES|Media Capabilities]] API.
 
@@ -1725,6 +1725,7 @@ following additional fields:
     without any associated metadata.  (This is the case, for example, with the
     "hlg" `transfer-function`.)
 
+    The media receiver should ignore duplicate entries in `hdr-formats.`
     If no `hdr-formats` are listed, then the media reciever cannot decode any
     HDR formats.
 

--- a/index.bs
+++ b/index.bs
@@ -1694,14 +1694,25 @@ following additional fields:
     display could return this value as 1.6 to indicate its preferred content
     scaling. Default is none.
 
-Issue(194): Expose capabilities for decoding HDR transfer functions and metadata formats.
-
 : color-gamuts (optional)
 :: An optional field indicating what color spaces can be decoded and rendered by
     the media receiver.  The media sender may use these values to determine how
     to encode video. Valid values correspond to [[MEDIA-CAPABILITIES#colorgamut|ColorGamut]]
     in the [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is
     a list with the single entry "srgb".
+
+: transfer-functions (optional)
+:: An optional field indicating what HDR transfer functions can be decoded and rendered
+    by the media receiver.  Valid values correspond to
+    [[MEDIA-CAPABILITIES#transferfunction|TransferFunction]] in the
+    [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is a list with the
+    single entry "srgb".
+
+: hdr-metadata (optional)
+:: An optional field indicating what HDR metadata types can be decoded and rendered by
+    by the media receiver.  Valid values correspond to
+    [[MEDIA-CAPABILITIES#hdrmetadatatype|HdrMetadataType]] in the
+    [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is an empty list.
 
 : native-resolutions (optional)
 :: An optional field indicating what video-resolutions the media receiver supports and

--- a/index.bs
+++ b/index.bs
@@ -1709,18 +1709,25 @@ following additional fields:
     in the [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is
     a list with the single entry "srgb".
 
-: transfer-functions (optional)
-:: An optional field indicating what HDR transfer functions can be decoded and rendered
-    by the media receiver.  Valid values correspond to
-    [[MEDIA-CAPABILITIES#transferfunction|TransferFunction]] in the
-    [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is a list with the
-    single entry "srgb".
+: hdr-formats (optional)
+:: An optional field indicating what HDR transfer functions and metadata formats
+    can be decoded and rendered by the media receiver.  Each `video-hdr-format`
+    consists of two fields, `transfer-function` and `hdr-metadata`.
 
-: hdr-metadata (optional)
-:: An optional field indicating what HDR metadata types can be decoded and rendered by
-    by the media receiver.  Valid values correspond to
-    [[MEDIA-CAPABILITIES#hdrmetadatatype|HdrMetadataType]] in the
-    [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is an empty list.
+    The `transfer-function` field must be a valid
+    [[MEDIA-CAPABILITIES#transferfunction|TransferFunction]]
+    and the `hdr-metadata` must be a valid
+    [[MEDIA-CAPABILITIES#hdrmetadatatype|HdrMetadataType]], both defined in the
+    [[!MEDIA-CAPABILITIES|Media Capabilities]] API.
+
+    If a `video-hdr-format` is provided with a `transfer-function` but no
+    `hdr-metadata`, then the media receiver can render the `transfer-function`
+    without any associated metadata.  (This is the case, for example, with the
+    "hlg" `transfer-function`.)
+
+    If no `hdr-formats` are listed, then the media reciever cannot decode any
+    HDR formats.
+
 
 : native-resolutions (optional)
 :: An optional field indicating what video-resolutions the media receiver supports and

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -553,6 +553,11 @@ video-resolution = {
   1: uint ; width
 }
 
+video-hdr-format = {
+  0: transfer-function ; string
+  1: ? hdr-metadata ; string
+}
+
 receive-video-capability = {
   0: format ; codec
   ? 1: video-resolution ; max-resolution
@@ -561,11 +566,10 @@ receive-video-capability = {
   ? 4: uint ; min-bit-rate
   ? 5: ratio ; aspect-ratio
   ? 6: [* string] ; color-gamuts
-  ? 7: [* string] ; transfer-functions
-  ? 8: [* string] ; hdr-metadata
-  ? 9: [* video-resolution] ; native-resolutions
-  ? 10: bool ; supports-scaling
-  ? 11: bool ; supports-rotation
+  ? 7: [* video-hdr-format] ; hdr-formats
+  ? 8: [* video-resolution] ; native-resolutions
+  ? 9: bool ; supports-scaling
+  ? 10: bool ; supports-rotation
 }
 
 receive-data-capability = {

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -561,9 +561,11 @@ receive-video-capability = {
   ? 4: uint ; min-bit-rate
   ? 5: ratio ; aspect-ratio
   ? 6: [* string] ; color-gamuts
-  ? 7: [* video-resolution] ; native-resolutions
-  ? 8: bool ; supports-scaling
-  ? 9: bool ; supports-rotation
+  ? 7: [* string] ; transfer-functions
+  ? 8: [* string] ; hdr-metadata
+  ? 9: [* video-resolution] ; native-resolutions
+  ? 10: bool ; supports-scaling
+  ? 11: bool ; supports-rotation
 }
 
 receive-data-capability = {

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -566,10 +566,10 @@ receive-video-capability = {
   ? 4: uint ; min-bit-rate
   ? 5: ratio ; aspect-ratio
   ? 6: [* string] ; color-gamuts
-  ? 7: [* video-hdr-format] ; hdr-formats
-  ? 8: [* video-resolution] ; native-resolutions
-  ? 9: bool ; supports-scaling
-  ? 10: bool ; supports-rotation
+  ? 7: [* video-resolution] ; native-resolutions
+  ? 8: bool ; supports-scaling
+  ? 9: bool ; supports-rotation
+  ? 10: [* video-hdr-format] ; hdr-formats
 }
 
 receive-data-capability = {


### PR DESCRIPTION
Addresses Issue #194: [Remote Playback] Capabilities for HDR rendering and display

This adds two fields to the `receive-video-capability` message that allows the receiver to list the HDR metadata types and transfer functions that the media receiver can accept.

The values are used by reference from the corresponding enums in the Media Capabilities API.  This was discussed, briefly, in the minutes of the joint SSWG/Media WG meeting:

https://www.w3.org/2022/01/11-mediawg-minutes.html#t01


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/300.html" title="Last updated on Oct 31, 2022, 5:38 PM UTC (cd9280d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/300/37cef31...cd9280d.html" title="Last updated on Oct 31, 2022, 5:38 PM UTC (cd9280d)">Diff</a>