### PR TITLE
Define the agent fingerprint as the SPKI.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -288,12 +288,8 @@ Advertising agents must include DNS TXT records with the following
 keys and values:
 
 : fp
-:: The <dfn>agent fingerprint</dfn> of the advertising agent, computed over the
-    [=agent certificate=]. The format of the fingerprint is defined by [[!RFC5122]],
-    excluding the "fingerprint:" prefix and including the hash function, space,
-    and hex-encoded fingerprint.  The fingerprint value also functions as an ID
-    for the agent. All agents must support the following hash functions: [=sha-256=],
-    [=sha-512=].  Agents must not support the following hash functions: [=md2=], [=md5=].
+:: The [=agent fingerprint=] of the advertising agent. The steps to compute
+    the agent fingerprint are defined below.
 
 : mv
 :: An unsigned integer value that indicates that
@@ -318,6 +314,19 @@ capabilities mechanism to be determined. If a future version of the Open Screen
 Protocol uses mDNS but breaks compatibility with the metadata discovery process,
 it should change the DNS-SD service name to a new value, indicating a new
 mechanism for metadata discovery.
+
+
+Computing the Agent Fingerprint {#computing-agent-fingerprint}
+-------------------------------
+
+The <dfn>agent fingerprint</dfn> of an agent is computed by following these
+steps:
+
+1. Compute the [[RFC7469#section-2.4|SKPI Fingerprint]] of the [=agent certificate=]
+    according to [[!RFC7469]] using [[RFC6234|SHA-256]] as the hash algorithm.
+2. base64 encode the result of Step 1 according to [[!RFC4648]].
+
+Note: The resulting string will be 44 bytes in length.
 
 
 Transport and metadata discovery with QUIC {#transport}
@@ -345,7 +354,7 @@ be used to communicate with a specific OSP Agent using OSP.  An OSP Agent may
 refuse incoming connections that lack these parameters.
 
 * The [[!RFC7301|ALPN]] used must be "osp".
-* The [[!RFC6066|server_name extension]] must be set to the following `host_name`: 
+* The [[!RFC6066|server_name extension]] must be set to the following `host_name`:
     `<fp>._openscreen._udp`.
     * `<fp>` must be substituted with the [=agent fingerprint=] as used in mDNS TXT.
 
@@ -489,7 +498,7 @@ The various capabilities have the following meanings:
     protocols may report more specific capabilities, such as support for
     certain audio codecs in the streaming protocol.
 
-: receive-video 
+: receive-video
 :: The agent can receive video via the other protocols it supports.  Those other
     protocols may report more specific capabilities, such as support for
     certain video codecs in the streaming protocol.
@@ -1088,7 +1097,7 @@ requirements for a remote-playback-id.
 :: The [=media resources=] that the controller has selected for playback
     on the receiver.  Each source must include a <{source/src|source URL}>
     and should include an <{source/type|extended MIME type}>.
-    
+
 Issue(265): Should media resource URLs be optional?
 
 : text-track-urls
@@ -1255,7 +1264,7 @@ intentionally mirror settable attributes and methods of the
     {{HTMLMediaElement/src|HTMLMediaElement.src}}
     for more details. Must not be used in the initial controls of the
     [=remote-playback-start-request=] message (which already contains a list of URLs).
-    
+
 Issue(223): Codec switching when remoting.
 
 : preload
@@ -1758,7 +1767,7 @@ Each stream offer contains the following fields:
 : audio
 :: A list of audio encodings offered.  An audio encoding is a series
     of encoded audio frames.  Encodings define fields needed by
-    the receiver to know how to decode the encoding, such as codec. 
+    the receiver to know how to decode the encoding, such as codec.
     They can differ by codec and related fields, but should be different
     encodings of the same audio.
 

--- a/index.bs
+++ b/index.bs
@@ -292,11 +292,11 @@ keys and values:
     the agent fingerprint are defined below.
 
 : mv
-:: An unsigned integer value that indicates that
-    metadata has changed.   The advertising agent must update it to a greater
-    value.  This signals to the listening agent that it should connect to the
-    advertising agent to discover updated metadata.  The value should be encoded
-    as a [=variable-length integer=].
+:: An unsigned integer value that indicates that metadata has changed.   The
+    advertising agent must update it to a greater value.  This signals to the
+    listening agent that it should connect to the advertising agent to discover
+    updated metadata.  The value should be encoded as a
+    [=variable-length integer=].
 
 : at
 :: An alphanumeric, unguessable token consisting of characters from the set
@@ -2700,9 +2700,10 @@ before being shown in full as a [=verified display name=].
 This means there are three categories of display names that agents should be
 capable of handling:
 <ol>
-  <li>Truncated and unverified DNS-SD Instance Names, which should not be shown to the user.</li>
-  <li>Complete but unverified DNS-SD Instance Names, which can be shown as
-     unverified prior to [[#authentication]].</li>
+  <li> Truncated and unverified DNS-SD Instance Names, which should not be shown
+       to the user.</li>
+  <li> Complete but unverified DNS-SD Instance Names, which can be shown as
+       unverified prior to [[#authentication]].</li>
   <li>Verified display names.</li>
 </ol>
 </div>


### PR DESCRIPTION
Addresses Issue #282: Certificates should have a maximum lifetime, and SPAKE2 identities should be SPKI not cert fingerprint

This defines the agent fingerprint in terms of the SPKI (e.g., the public key) of the agent certificate.  The agent fingerprint is used to identify agents and is input to SPAKE2.

This allows agents to use shorter-lived certificates and renew their certificates without having to re-authenticate to other agents.

This PR does not specify certificate lifetimes or renewal policies.  It also does not handle the issuing of completely new certificates while maintaining previous trust relationships.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/301.html" title="Last updated on Jan 22, 2024, 8:26 PM UTC (596e9f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/301/15ed7a5...596e9f3.html" title="Last updated on Jan 22, 2024, 8:26 PM UTC (596e9f3)">Diff</a>