### PR TITLE
Attempt to fix the spec.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -30,7 +30,6 @@ urlPrefix: https://www.w3.org/TR/presentation-api/#dfn-; type: dfn; spec: PRESEN
     text: presentation id
     text: presentation request url
     text: receiving user agent
-    text: creating a receiving browsing context
 urlPrefix: https://w3c.github.io/remote-playback/#dfn-; type: dfn; spec: REMOTE-PLAYBACK
     text: availability sources set
     text: compatible remote playback device

--- a/index.bs
+++ b/index.bs
@@ -23,13 +23,14 @@ urlPrefix: https://html.spec.whatwg.org/multipage/media.html#; type: dfn; spec: 
     text: official playback position
     text: poster frame
     text: timeline offset
-urlPrefix: https://w3c.github.io/presentation-api/#dfn-; type: dfn; spec: PRESENTATION-API
+urlPrefix: https://www.w3.org/TR/presentation-api/#dfn-; type: dfn; spec: PRESENTATION-API
     text: available presentation display
     text: controlling user agent
     text: presentation
     text: presentation id
     text: presentation request url
     text: receiving user agent
+    text: creating a receiving browsing context
 urlPrefix: https://w3c.github.io/presentation-api/; type: interface; spec: PRESENTATION-API
     text: PresentationConnection
 urlPrefix: https://w3c.github.io/remote-playback/#dfn-; type: dfn; spec: REMOTE-PLAYBACK
@@ -782,7 +783,7 @@ values:
 
 : headers
 :: headers that the receiver should use to fetch the presentation URL.  For example,
-    [[PRESENTATION-API#establishing-a-presentation-connection|section 6.6.1]] of
+    [[PRESENTATION-API#creating-a-receiving-browsing-context|section 6.6.1]] of
     the Presentation API says that the Accept-Language header should be
     provided.
 

--- a/index.bs
+++ b/index.bs
@@ -31,7 +31,7 @@ urlPrefix: https://www.w3.org/TR/presentation-api/#dfn-; type: dfn; spec: PRESEN
     text: presentation request url
     text: receiving user agent
     text: creating a receiving browsing context
-urlPrefix: https://w3c.github.io/presentation-api/; type: interface; spec: PRESENTATION-API
+urlPrefix: https://www.w3.org/TR/presentation-api/; type: interface; spec: PRESENTATION-API
     text: PresentationConnection
 urlPrefix: https://w3c.github.io/remote-playback/#dfn-; type: dfn; spec: REMOTE-PLAYBACK
     text: availability sources set

--- a/index.bs
+++ b/index.bs
@@ -31,8 +31,6 @@ urlPrefix: https://www.w3.org/TR/presentation-api/#dfn-; type: dfn; spec: PRESEN
     text: presentation request url
     text: receiving user agent
     text: creating a receiving browsing context
-urlPrefix: https://www.w3.org/TR/presentation-api/; type: interface; spec: PRESENTATION-API
-    text: PresentationConnection
 urlPrefix: https://w3c.github.io/remote-playback/#dfn-; type: dfn; spec: REMOTE-PLAYBACK
     text: availability sources set
     text: compatible remote playback device
@@ -1400,13 +1398,13 @@ changed.
 : loading
 :: The state of network activity for loading the [=media resource=]. See
     {{HTMLMediaElement/networkState|HTMLMediaElement.networkState}}.
-    The default is empty ({{NETWORK_EMPTY}}
+    The default is empty ({{NETWORK_EMPTY}})
     for the initial state in the [=remote-playback-start-response=] message.
 
 : loaded
 :: The state of the loaded media (whether enough is loaded to play). See
     {{HTMLMediaElement/readyState|HTMLMediaElement.readyState}}.
-    The default is nothing ({{HAVE_NOTHING}}
+    The default is nothing ({{HAVE_NOTHING}})
     for the initial state in the [=remote-playback-start-response=] message.
 
 : error
@@ -1582,10 +1580,10 @@ This is how the [[REMOTE-PLAYBACK|Remote Playback API]] uses the
 messages defined in [[#remote-playback-protocol]]:
 
 When [[REMOTE-PLAYBACK#the-list-of-available-remote-playback-devices|section
-6.2.1.2]] says "This list contains [=remote playback devices=] and is populated
+5.2.1.2]] says "This list contains [=remote playback devices=] and is populated
 based on an implementation specific discovery mechanism" and
 [[REMOTE-PLAYBACK#the-list-of-available-remote-playback-devices|section
-6.2.1.4]] says "Retrieve available remote playback devices (using an
+5.2.1.4]] says "Retrieve available remote playback devices (using an
 implementation specific mechanism)", the user agent may use the mDNS, QUIC,
 [=agent-info-request=], and [=remote-playback-availability-request=] messages
 defined previously in this spec to discover [=receivers=].  The
@@ -1594,7 +1592,7 @@ sources set=].
 
 When
 [[REMOTE-PLAYBACK#establishing-a-connection-with-a-remote-playback-device|section
-6.2.4]] says "Request connection of remote to device. The implementation of this
+5.2.4]] says "Request connection of remote to device. The implementation of this
 step is specific to the user agent." and "Synchronize the current media element
 state with the remote playback state", the controller may send the
 [=remote-playback-start-request=] message to the receiver to start remote
@@ -1605,7 +1603,7 @@ of [[REMOTE-PLAYBACK|Remote Playback API]] may allow for several.
 
 When
 [[REMOTE-PLAYBACK#establishing-a-connection-with-a-remote-playback-device|section
-6.2.4]] says "The mechanism that is used to connect the user agent with the
+5.2.4]] says "The mechanism that is used to connect the user agent with the
 remote playback device and play the remote playback source is an implementation
 choice of the user agent. The connection will likely have to provide a two-way
 messaging abstraction capable of carrying media commands to the remote playback
@@ -1617,8 +1615,8 @@ based on changes to the local media element and receive
 change the local media element based on changes to the remote playback state.
 
 When
-[[REMOTE-PLAYBACK#establishing-a-connection-with-a-remote-playback-device|section
-6.2.7]] says "Request disconnection of remote from the device. The
+[[REMOTE-PLAYBACK#disconnecting-from-a-remote-playback-device|section
+5.2.7]] says "Request disconnection of remote from the device. The
 implementation of this step is specific to the user agent," the controller may
 send the [=remote-playback-termination-request=] message to the receiver.
 

--- a/index.bs
+++ b/index.bs
@@ -784,7 +784,7 @@ values:
 : headers
 :: headers that the receiver should use to fetch the presentation URL.  For example,
     [[PRESENTATION-API#creating-a-receiving-browsing-context|section 6.6.1]] of
-    the Presentation API says that the Accept-Language header should be
+    the Presentation API says that the HTTP `Accept-Language` header should be
     provided.
 
 The presentation ID must follow the restrictions defined by


### PR DESCRIPTION
Addresses #303: Cross-spec links are broken

Thanks to fixes upstream to Bikeshed the existing section and HTML references now work.
Thank you @tidoust!

This PR just tidies up a few xrefs.

(If we land PRs to export additional terms from other specs, we could reduce the size of the anchors block, but that's for another day.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/302.html" title="Last updated on Oct 14, 2022, 8:55 PM UTC (42124c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/302/c2d4001...42124c3.html" title="Last updated on Oct 14, 2022, 8:55 PM UTC (42124c3)">Diff</a>