### PR TITLE
Convert color-gamut to be a single value.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1770,12 +1770,15 @@ following additional fields:
     display could return this value as 1.6 to indicate its preferred content
     scaling. Default is none.
 
-: color-gamuts (optional)
+: color-gamut (optional)
 :: An optional field indicating what color spaces can be decoded and rendered by
-    the media receiver.  The media sender may use these values to determine how
+    the media receiver.  The media sender may use this value to determine how
     to encode video. Valid values correspond to [[MEDIA-CAPABILITIES#colorgamut|ColorGamut]]
     in the [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is
-    a list with the single entry "srgb".
+    "srgb".
+
+NOTE: Support for "p3" implies support for "srgb", and support for "rec2020"
+implies support for "p3" and "srgb".
 
 : hdr-formats (optional)
 :: An optional field indicating what HDR transfer functions and metadata formats

--- a/index.bs
+++ b/index.bs
@@ -1771,9 +1771,10 @@ following additional fields:
     scaling. Default is none.
 
 : color-gamut (optional)
-:: An optional field indicating what color spaces can be decoded and rendered by
-    the media receiver.  The media sender may use this value to determine how
-    to encode video. Valid values correspond to [[MEDIA-CAPABILITIES#colorgamut|ColorGamut]]
+:: An optional field indicating the widest color space that can be decoded and
+    rendered by the media receiver.  The media sender may use this value to
+    determine how to encode video, and should assume all narrower color spaces
+    are supported.  Valid values correspond to [[MEDIA-CAPABILITIES#colorgamut|ColorGamut]]
     in the [[!MEDIA-CAPABILITIES|Media Capabilities]] API.  The default value is
     "srgb".
 

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -565,7 +565,7 @@ receive-video-capability = {
   ? 3: uint ; max-pixels-per-second
   ? 4: uint ; min-bit-rate
   ? 5: ratio ; aspect-ratio
-  ? 6: [* string] ; color-gamuts
+  ? 6: string ; color-gamut
   ? 7: [* video-resolution] ; native-resolutions
   ? 8: bool ; supports-scaling
   ? 9: bool ; supports-rotation


### PR DESCRIPTION
Fixes #305.  This converts color-gamuts to be a single value, not a list, as support for a wider gamut implies support for narrower gamuts.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/311.html" title="Last updated on Oct 13, 2023, 10:21 PM UTC (7cd67df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/311/212162c...7cd67df.html" title="Last updated on Oct 13, 2023, 10:21 PM UTC (7cd67df)">Diff</a>