### PR TITLE
Remove codec parameters.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1877,7 +1877,7 @@ Each audio encoding offered defines the following fields:
 
 : codec-name
 :: The name of the codec used by the encoding, following the same
-    rules as `codec-name` in [=streaming-capabilities-response=].
+    rules as `codec-name` in [[#streaming-protocol-capabilities]].
 
 : time-scale
 :: The [=time scale=] used by all audio frames.  This allows senders to

--- a/index.bs
+++ b/index.bs
@@ -1899,7 +1899,7 @@ Each video encoding offered defines the following fields:
 
 : codec-name
 :: The name of the codec used by the encoding, following the same
-    rules as `codec-name` in [[#streaming-capabilities-response]].
+    rules as `codec-name` in [[#streaming-protocol-capabilities]].
 
 : time-scale
 :: The [=time scale=] used by all video frames.  This allows senders to

--- a/index.bs
+++ b/index.bs
@@ -1719,20 +1719,13 @@ following fields:
 The format type is used as the basis for audio and video capabilities.
 Formats are composed of the following fields:
 
-: name (required)
+: codec-name (required)
 :: A fully qualified codec string listed in the [[WEBCODECS-CODEC-REGISTRY]] and further
      specified by the codec-specific registrations referenced in that registry.
 
-: parameters (required)
-:: A list of (key, value) parameters that can be used to describe
-    properties of a specific format, and not shared by other formats
-    of that type (audio, video, etc.).
-
-For `name`, Open Screen agents may also accept a single-codec [=codec
+For `codec-name`, Open Screen agents may also accept a single-codec [=codec
 parameter=] as described in [[!RFC6381]] for codecs not listed in the
 [[WEBCODECS-CODEC-REGISTRY]].
-
-Issue(266): Specify where codec-specific parameters are defined or drop them.
 
 Audio capabilities are composed of the above format type, with the following
 additional fields:
@@ -1883,8 +1876,8 @@ Each audio encoding offered defines the following fields:
     [[#requests-responses-watches]].
 
 : codec-name
-:: The name of the codec used by the encoding.  This must be a single-codec
-    RFC 6381 [=codecs parameter=].
+:: The name of the codec used by the encoding, following the same
+    rules as `codec-name` in [=streaming-capabilities-response=].
 
 : time-scale
 :: The [=time scale=] used by all audio frames.  This allows senders to
@@ -1905,7 +1898,8 @@ Each video encoding offered defines the following fields:
     [[#requests-responses-watches]].
 
 : codec-name
-:: The name of the codec used by the encoding.
+:: The name of the codec used by the encoding, following the same
+    rules as `codec-name` in [=streaming-capabilities-response=].
 
 : time-scale
 :: The [=time scale=] used by all video frames.  This allows senders to
@@ -1994,8 +1988,8 @@ Audio {#streaming-audio}
 [=Media senders=] may send audio to [=media receivers=] by sending
 [=audio-frame=] messages (see [[#appendix-a]]) with the following keys and
 values.  An audio frame message contains a set of encoded audio samples for a
-range of time. A series of encoded audio frames that share a codec, codec
-parameters and a timeline form an audio encoding.
+range of time. A series of encoded audio frames that share a codec and a
+timeline form an audio encoding.
 
 Unlike most Open Screen Protocol messages, this one uses an
 array-based grouping rather than a struct-based grouping.  For
@@ -2038,9 +2032,8 @@ separate QUIC streams.
     be; it can be any clock chosen by the media sender.
 
 : payload
-:: The encoded audio.  The codec and codec parameters are equal to the
-    `codec-name` field of the [=audio-encoding-offer=] message referenced by
-    the `encoding-id`.
+:: The encoded audio.  The codec is equal to the `codec-name` field of the
+    [=audio-encoding-offer=] message referenced by the `encoding-id`.
 
 Video {#streaming-video}
 --------------------------------------------
@@ -2049,8 +2042,7 @@ Media senders may send video to media receivers by sending [=video-frame=]
 messages (see [[#appendix-a]]) with the following keys and values.  A video
 frame message contains an encoded video frame (an encoded image) at a specific
 point in time or over a specfic time range (if the duration is known).  A series
-of encoded video frames that share a codec, codec parameters and a timeline form
-a video encoding.
+of encoded video frames that share a codec and a timeline form a video encoding.
 
 To allow for video frames to be sent out of order, they may be sent in
 separate QUIC streams.  If the encoding is a long chain of encoded video frames
@@ -2102,9 +2094,9 @@ ending at the last dependent frame.
     referenced by the `encoding-id`.
 
 : payload
-:: The encoded video frame (encoded image).  The codec and codec
-     parameters are equal to the `codec-name` field of the
-     [=video-encoding-offer=] message referenced by the `encoding-id`.
+:: The encoded video frame (encoded image).  The codec is equal to the
+    `codec-name` field of the [=video-encoding-offer=] message referenced
+    by the `encoding-id`.
 
 Data {#streaming-data}
 ------------------------------------

--- a/index.bs
+++ b/index.bs
@@ -1899,7 +1899,7 @@ Each video encoding offered defines the following fields:
 
 : codec-name
 :: The name of the codec used by the encoding, following the same
-    rules as `codec-name` in [=streaming-capabilities-response=].
+    rules as `codec-name` in [[#streaming-capabilities-response]].
 
 : time-scale
 :: The [=time scale=] used by all video frames.  This allows senders to

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -533,13 +533,7 @@ streaming-capabilities = {
 }
 
 format = {
-  0: string ; name
-  1: [* format-parameter] ; parameters
-}
-
-format-parameter = {
-  0: string ; key
-  1: bytes ; value
+  0: string ; codec-name
 }
 
 receive-audio-capability = {


### PR DESCRIPTION
Addresses #266 by removing codec parameters from the `streaming-capabilities-response` message.

Full codec strings should carry sufficient information to describe the encoding.  For example, see the specification of the vp9 codec string:

https://github.com/webmproject/vp9-dash/blob/master/VPCodecISOMediaFileFormatBinding.md#codecs-parameter-string


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/312.html" title="Last updated on Oct 4, 2023, 10:28 PM UTC (c2cf850)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/312/212162c...c2cf850.html" title="Last updated on Oct 4, 2023, 10:28 PM UTC (c2cf850)">Diff</a>