### PR TITLE
Update capabilities table.

### DIFF
--- a/capabilities.md
+++ b/capabilities.md
@@ -11,21 +11,17 @@ Screen Protocol](https://webscreens.github.io/openscreenprotocol/#transport).
 
 ## Open Screen Protocol Capabilities
 
-[TODO(Issue #254): Finish the capabilities table.](issues/254)
-
 | Id |     Name                  |         Description         | Message Type IDs      |
 |----|---------------------------|-----------------------------|-----------------------|
 | 1  | `receive-audio`           | Audio Receiver              | 22                    |
 | 2  | `receive-video`           | Video Receiver              | 23                    |
 | 3  | `receive-presentation`    | Presentation API Receiver   | 14,16,104,106,109,113 |
 | 4  | `control-presentation`    | Presentation API Controller | 15,16,103,105,107,108,110,113,121 |
-| 5  | `receive-remote-playback` | Remote Playback Receiver    | 17,115,117,119        |
+| 5  | `receive-remote-playback` | Remote Playback Receiver    | 17,19,115,117,119     |
 | 6  | `control-remote-playback` | Remote Playback Controller  | 18,20,21,114,116,118  |
-| 7  | `receive-streaming`       | Streaming Receiver          | 24                    |
-| 8  | `send-streaming`          | Streaming Sender            |                       |
-
-
-
+| 7  | `receive-streaming`       | Streaming Receiver          | 122,124,127,129,131   |
+| 8  | `send-streaming`          | Streaming Sender            | 123,125,126,128,130,132 |
+| 9  | `receive-data`            | Data Receiver               | 24                    |
 
 ## Extension Capabilities
 

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -503,13 +503,6 @@ data-frame = {
   ? 5: media-time ; sync-time
 }
 
-; type key 120
-video-frame-request = {
- 1: uint; encoding-id
- 2: uint; sequence-number
- ? 3: uint; highest-decoded-frame-sequence-number
-}
-
 ratio = [
   antecedent: uint
   consequent: uint
@@ -611,7 +604,7 @@ streaming-session-start-response-params = (
 streaming-session-modify-request-params = (
   1: uint ; streaming-session-id
   2: [* media-stream-request] ; stream-requests
-}
+)
 
 ; type key 127
 streaming-session-modify-response = {


### PR DESCRIPTION
This addresses #254 by assigning remaining message types in the protocol to capabilities in the table.

A new capability `receive-data` is added to the table since there was no existing capability to receive message type 24 (data frames).

`video-request-format` was removed from the list of message definitions because there was no reference to it in the spec.