### PR TITLE
Change remote playback update interval to 250ms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1263,13 +1263,16 @@ The [=timeline offset=] associated with the playback changes since the last sent
 
 The {{stalled}} event needs to fire at the associated {{HTMLMediaElement}} instance.
 
-More than 350ms pass since the last [=remote-playback-state-event=] message
+More than 250ms pass since the last [=remote-playback-state-event=] message
   and any of the following attributes observably change since the last
   [=remote-playback-state-event=] message. Any new continuously changing
   attributes fall under this rule.
 
 * {{HTMLMediaElement/played|HTMLMediaElement.played}}
 * {{HTMLMediaElement/currentTime|HTMLMediaElement.currentTime}}
+
+NOTE: A media element is required to fire a {{HTMLMediaElement/timeupdate}}
+event every 250ms or sooner.
 
 : remote-playback-id
 :: The ID of the remote playback whose state has changed.


### PR DESCRIPTION
Addresses Issue #159.

This changes the maximum interval to send a `remote-playback-state-event` from the receiver to the controller to 250ms to align with HTML.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/316.html" title="Last updated on Sep 11, 2023, 12:03 AM UTC (401a081)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/316/212162c...401a081.html" title="Last updated on Sep 11, 2023, 12:03 AM UTC (401a081)">Diff</a>