### PR TITLE
Update language around private browsing.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2519,16 +2519,16 @@ available to the Web and should be designed accordingly.
 
 Below, we discuss mitigation steps to prevent malicious use of these devices.
 
-### Incognito Mode ### {#incognito-mode}
+### Private Browsing Mode ### {#private-browsing-mode}
 
-The Open Screen Protocol does not distinguish between the user agent's normal
-browsing and incognito modes, and agents that follow the specification
-behave identically regardless of which mode is in use.
+The Open Screen Protocol itself does not distinguish between the user agent's normal
+browsing and [private browsing](https://www.w3.org/2001/tag/doc/private-browsing-modes/)
+modes.
 
-It's recommended that user agents use separate authentication contexts and QUIC
-connections for normal and incognito profiles from the same user agent instance.
-This prevents OSP agents from correlating activity among profiles
-belonging to the same user (both normal and incognito).
+However, it's recommended that user agents use separate authentication contexts
+and QUIC connections for normal and private browsing from the same user agent
+instance.  This makes it more difficult for OSP agents to match activities
+occurring in normal and private browsing by the same user.
 
 ### Persistent State ### {#persistent-state}
 

--- a/index.bs
+++ b/index.bs
@@ -2526,9 +2526,10 @@ browsing and [private browsing](https://www.w3.org/2001/tag/doc/private-browsing
 modes.
 
 However, it's recommended that user agents use separate authentication contexts
-and QUIC connections for normal and private browsing from the same user agent
-instance.  This makes it more difficult for OSP agents to match activities
-occurring in normal and private browsing by the same user.
+(see [[#authentication]]) and QUIC connections (see [[#transport]]) for normal and
+private browsing from the same user agent instance. This makes it more difficult
+for OSP agents to match activities occurring in normal and private browsing by the
+same user.
 
 ### Persistent State ### {#persistent-state}
 


### PR DESCRIPTION
Addresses Issue #132.

Clarify how private browsing should be handled by OSP implementations.

Replaces "incognito" with "private browsing" and links to the TAG finding on private browsing.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/317.html" title="Last updated on Oct 4, 2023, 10:32 PM UTC (a65c00d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/317/212162c...a65c00d.html" title="Last updated on Oct 4, 2023, 10:32 PM UTC (a65c00d)">Diff</a>