### PR TITLE
Add note about maximum latency.

### DIFF
--- a/biblio.json
+++ b/biblio.json
@@ -6,9 +6,12 @@
     "publisher": "ISO/IEC",
     "isoNumber": "ISO 18004:2015",
     "rawDate": "2015-02"
+  },
+  "ITU-R-BT.1359-1": {
+    "href": "https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.1359-1-199811-I!!PDF-E.pdf",
+    "title": "ITU-R BT.1359-1, Relative Timing of Sound and Vision for Broadcasting",
+    "status": "Recommendation",
+    "publisher": "ITU",
+    "rawDate": "1998-11"
   }
 }
-
-  
-
-

--- a/index.bs
+++ b/index.bs
@@ -889,12 +889,14 @@ To send a presentation message, the controller or receiver may send a
 : message
 :: The presentation message data.
 
-NOTE: An OSP agent should minimize the latency between applications sending or
-receiving messages and the underlying QUIC connection, as messages may be used
-to synchronize playback of media streams between agents.  The synchronization
-thresholds recommended in [[ITU-R-BT.1359-1]] imply that the total message
-processing latency by agents must be no greater than 45 ms to permit effective
-lip sync during media playback.
+NOTE: An OSP agent should minimize buffering and processing of messages sent or
+received via the QUIC connection beyond what is strictly necessary (i.e., CBOR
+serialization).  Message payloads should be treated as real-time data, as they
+may be used to synchronize playback of media streams between agents or other low
+latency use cases.  The synchronization thresholds recommended in
+[[ITU-R-BT.1359-1]] imply that the total agent-to-agent processing latency
+(including serialization, buffering, QUIC processing, and network latency) must
+be no greater than 45 ms to permit effective lip sync during media playback.
 
 To terminate a presentation, the controller may send a
 [=presentation-termination-request=] message with the following values:

--- a/index.bs
+++ b/index.bs
@@ -886,6 +886,12 @@ To send a presentation message, the controller or receiver may send a
 : message
 :: The presentation message data.
 
+NOTE: An OSP agent should minimize the latency between applications sending or
+receiving messages and the underlying QUIC connection, as messages may be used
+to synchronize playback of media streams between agents.  The synchronization
+thresholds recommended in [[ITU-R-BT.1359-1]] imply that the total message
+processing latency by agents must be no greater than 45 ms to permit effective
+lip sync during media playback.
 
 To terminate a presentation, the controller may send a
 [=presentation-termination-request=] message with the following values:


### PR DESCRIPTION
Addresses Issue #80 by adding an implementation note about message playback and placing an upper bound on message handling latency.

Basically for latency, "the lower the better," but this uses the ITU recommendation as an upper bound.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/319.html" title="Last updated on Oct 16, 2023, 5:17 PM UTC (0cdd969)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/319/ee2b93f...0cdd969.html" title="Last updated on Oct 16, 2023, 5:17 PM UTC (0cdd969)">Diff</a>