### PR TITLE
Correct agent cert fingerprint RFC.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -291,7 +291,7 @@ keys and values:
 
 : fp
 :: The <dfn>agent fingerprint</dfn> of the advertising agent, computed over the
-    [=agent certificate=]. The format of the fingerprint is defined by [[!RFC5122]],
+    [=agent certificate=]. The format of the fingerprint is defined by [[!RFC8122]],
     excluding the "fingerprint:" prefix and including the hash function, space,
     and hex-encoded fingerprint.  The fingerprint value also functions as an ID
     for the agent. All agents must support the following hash functions: [=sha-256=],


### PR DESCRIPTION
[RFC5122](https://datatracker.ietf.org/doc/html/rfc5122) doesn't seem to contain any fingerprint definition. [RFC8122](https://datatracker.ietf.org/doc/html/rfc8122) does, so this may be a typo.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/backkem/openscreenprotocol/pull/322.html" title="Last updated on Oct 1, 2023, 10:58 AM UTC (0f150c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/322/710a30d...backkem:0f150c5.html" title="Last updated on Oct 1, 2023, 10:58 AM UTC (0f150c5)">Diff</a>