### PR TITLE
Add steps to implement presentationConnection.reconnect().

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1028,9 +1028,12 @@ controller) may send a [=presentation-start-request=] message to D
 (the receiver), with I for the [=presentation identifier=] and presentationUrl
 for the selected presentation URL.
 
-Issue(w3c/presentation-api#471): Once the Presentation API has text about
-reconnecting via an implementation specific mechanism, quote that here and map
-it to a message.
+When [[PRESENTATION-API#reconnecting-to-a-presentation|section 6.3.5]] says to
+"establish a presentation connection with newConnection," let U be the
+presentationURL of `newConnection` and I the presentation identifier of
+`newConnection.` The agent should send a
+[=presentation-connection-open-request=] with U for the `url` and I for the
+`presentation-id`.
 
 When [[PRESENTATION-API#sending-a-message-through-presentationconnection|section
 6.5.2]] says "Using an implementation specific mechanism, transmit the contents


### PR DESCRIPTION
Addresses Issue w3c/presentation-api#471, to fill in how OSP would implement `PresentationConnection.reconnect()`.