### PR TITLE
Clarify QUIC stream usage.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -601,7 +601,8 @@ groups of messages (with no ordering dependency across groups) should be sent in
 different QUIC streams.  In order to put multiple CBOR-serialized messages into
 the the same QUIC stream, the following is used.
 
-For each message, the [=OSP agent=] must write to the QUIC stream the following:
+For each message, the [=OSP agent=] must write into a unidirectional QUIC stream
+the following:
 
 1.  A type key representing the type of the message, encoded as a [=variable-length
     integer=] (see [[#appendix-a]] for type keys)
@@ -732,7 +733,7 @@ The messages used in this authentication method are: [=auth-spake2-handshake=],
 how [=auth-spake2-handshake=] and [=auth-spake2-confirmation=] are computed.
 
 The values `A` and `B` used in SPAKE2 are the [=agent fingerprints=] of the
-client and server, respectively. `pw` is the PSK presented to the user. 
+client and server, respectively. `pw` is the PSK presented to the user.
 
 The PSK presenter or the PSK consumer may initiate authentication (assuming the
 role of Alice in SPAKE2).


### PR DESCRIPTION
This resolves #333.  Unidirectional streams allow the writer to close immediately after the message is written.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/335.html" title="Last updated on May 31, 2024, 11:50 PM UTC (4581b3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/335/362a2fd...4581b3d.html" title="Last updated on May 31, 2024, 11:50 PM UTC (4581b3d)">Diff</a>