### PR TITLE
Add a NOTE about MAX_STREAMS for QUIC connections

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -43,7 +43,6 @@ url: https://datatracker.ietf.org/doc/html/rfc9000#name-transport-parameter-enco
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-connection_close-frames; type: dfn; spec: RFC9000; text: CONNECTION_CLOSE Frames
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-variable-length-integer-enc; type: dfn; spec: RFC9000; text: Variable-Length Integer Encoding
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-variable-length-integer-enc; type: dfn; spec: RFC9000; text: variable-length integer
-url: https://datatracker.ietf.org/doc/html/rfc9000#section-4.6; type: dfn; spec: RFC9000; text: max_streams
 url: https://tools.ietf.org/html/rfc6762#section-9; type: dfn; spec: RFC6762; text: conflict resolution
 url: https://tools.ietf.org/html/rfc6763#section-7; type: dfn; spec: RFC6763; text: service name
 url: https://tools.ietf.org/html/rfc6763#section-4.1.1; type: dfn; spec: RFC6763; text: instance name
@@ -603,6 +602,10 @@ groups of messages (with no ordering dependency across groups) should be sent in
 different QUIC streams.  In order to put multiple CBOR-serialized messages into
 the the same QUIC stream, the following is used.
 
+NOTE: Open Screen Agents should configure QUIC stream limits to not hinder
+application performance, keeping in mind the number of concurrent streams that
+may be necessary for audio, video, or data streaming use cases.
+
 For each message, the [=OSP agent=] must write into a unidirectional QUIC stream
 the following:
 
@@ -615,11 +618,6 @@ If an agent receives a message for which it does not recognize a type key, it
 must close the QUIC connection with an application error code of 404 and should
 include the unknown type key in the reason phrase of the [=CONNECTION_CLOSE
 frame=].
-
-NOTE: Open Screen Agents should negotiate a QUIC connection with a
-[=MAX_STREAMS=] of at least 2^30 to allow applications that send messages with
-high frequency over long-lived connections to not be blocked by QUIC concurrency
-limits.
 
 Variable-length integers are encoded in the [=Variable-Length Integer Encoding=]
 used by [[!RFC9000|QUIC]].

--- a/index.bs
+++ b/index.bs
@@ -43,6 +43,7 @@ url: https://datatracker.ietf.org/doc/html/rfc9000#name-transport-parameter-enco
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-connection_close-frames; type: dfn; spec: RFC9000; text: CONNECTION_CLOSE Frames
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-variable-length-integer-enc; type: dfn; spec: RFC9000; text: Variable-Length Integer Encoding
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-variable-length-integer-enc; type: dfn; spec: RFC9000; text: variable-length integer
+url: https://datatracker.ietf.org/doc/html/rfc9000#section-4.6; type: dfn; spec: RFC9000; text: max_streams
 url: https://tools.ietf.org/html/rfc6762#section-9; type: dfn; spec: RFC6762; text: conflict resolution
 url: https://tools.ietf.org/html/rfc6763#section-7; type: dfn; spec: RFC6763; text: service name
 url: https://tools.ietf.org/html/rfc6763#section-4.1.1; type: dfn; spec: RFC6763; text: instance name
@@ -602,9 +603,9 @@ groups of messages (with no ordering dependency across groups) should be sent in
 different QUIC streams.  In order to put multiple CBOR-serialized messages into
 the the same QUIC stream, the following is used.
 
-NOTE: Open Screen Agents should configure QUIC stream limits to not hinder
-application performance, keeping in mind the number of concurrent streams that
-may be necessary for audio, video, or data streaming use cases.
+NOTE: Open Screen Agents should configure QUIC stream limits ([=MAX_STREAMS=])
+to not hinder application performance, keeping in mind the number of concurrent
+streams that may be necessary for audio, video, or data streaming use cases.
 
 For each message, the [=OSP agent=] must write into a unidirectional QUIC stream
 the following:

--- a/index.bs
+++ b/index.bs
@@ -43,6 +43,7 @@ url: https://datatracker.ietf.org/doc/html/rfc9000#name-transport-parameter-enco
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-connection_close-frames; type: dfn; spec: RFC9000; text: CONNECTION_CLOSE Frames
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-variable-length-integer-enc; type: dfn; spec: RFC9000; text: Variable-Length Integer Encoding
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-variable-length-integer-enc; type: dfn; spec: RFC9000; text: variable-length integer
+url: https://datatracker.ietf.org/doc/html/rfc9000#section-4.6; type: dfn; spec: RFC9000; text: max_streams
 url: https://tools.ietf.org/html/rfc6762#section-9; type: dfn; spec: RFC6762; text: conflict resolution
 url: https://tools.ietf.org/html/rfc6763#section-7; type: dfn; spec: RFC6763; text: service name
 url: https://tools.ietf.org/html/rfc6763#section-4.1.1; type: dfn; spec: RFC6763; text: instance name
@@ -613,6 +614,11 @@ If an agent receives a message for which it does not recognize a type key, it
 must close the QUIC connection with an application error code of 404 and should
 include the unknown type key in the reason phrase of the [=CONNECTION_CLOSE
 frame=].
+
+NOTE: Open Screen Agents should negotiate a QUIC connection with a
+[=MAX_STREAMS=] of at least 2^30 to allow applications that send messages with
+high frequency over long-lived connections to not be blocked by QUIC concurrency
+limits.
 
 Variable-length integers are encoded in the [=Variable-Length Integer Encoding=]
 used by [[!RFC9000|QUIC]].


### PR DESCRIPTION
Addresses #334. 

MAX_STREAMS limits the number of QUIC streams that can be opened per connection.  Recommend a high value so that agents won't run into this limit in practice.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/336.html" title="Last updated on Sep 19, 2024, 6:44 PM UTC (880b286)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/336/9f704d4...880b286.html" title="Last updated on Sep 19, 2024, 6:44 PM UTC (880b286)">Diff</a>