### PR TITLE
Fix CDDL bug.

### DIFF
--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -113,8 +113,9 @@ auth-status = {
 
 ; type key 1005
 auth-spake2-handshake = {
-  0: auth-spake2-psk-status ; psk-status
-  1: bytes ; public-value
+  0: auth-initiation-token; token
+  1: auth-spake2-psk-status ; psk-status
+  2: bytes ; public-value
 }
 
 watch-id = uint

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -82,9 +82,9 @@ psk-input-method = &(
   qr-code: 1
 )
 
-auth-initiation-token = (
+auth-initiation-token = {
   ? 0: text ; token
-)
+}
 
 auth-spake2-psk-status = &(
   psk-needs-presentation: 0

--- a/messages_appendix.cddl
+++ b/messages_appendix.cddl
@@ -113,7 +113,7 @@ auth-status = {
 
 ; type key 1005
 auth-spake2-handshake = {
-  0: auth-initiation-token; token
+  0: auth-initiation-token; initiation-token
   1: auth-spake2-psk-status ; psk-status
   2: bytes ; public-value
 }


### PR DESCRIPTION
The usage of `auth-spake2-handshake` was dropped by accident. This PR fixes it.