### PR TITLE
Fix generation of application and network specs

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -36,6 +36,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install Pygments
 
+      # Note: the step actually generates all CDDL message pages, but the
+      # w3c/spec-prod action cleans these files after each build, so we'll
+      # have to generate them again each time.
       - name: Generate messages_appendix.html
         run: python scripts/pygmentize_dir.py
 
@@ -51,6 +54,9 @@ jobs:
           W3C_BUILD_OVERRIDE: |
             status: WD
 
+      - name: Generate application_messages.html
+        run: python scripts/pygmentize_dir.py
+
       - name: Build and validate application.html, push to gh-pages branch if needed
         uses: w3c/spec-prod@v2
         with:
@@ -58,6 +64,9 @@ jobs:
           TOOLCHAIN: bikeshed
           GH_PAGES_BRANCH: gh-pages
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN_APPLICATION }}
+
+      - name: Generate network_messages.html
+        run: python scripts/pygmentize_dir.py
 
       - name: Build and validate network.html, push to gh-pages branch if needed
         uses: w3c/spec-prod@v2


### PR DESCRIPTION
The w3c/spec-prod action cleans files at the end of a build, and drops the CDDL messages appendices files that need to be imported to build the application and network specs.

Workaround here is to re-generate the messages files each time.

Fix for https://github.com/w3c/openscreenprotocol/pull/344#issuecomment-2364521197
