### PR TITLE
Stop auto-publication to /TR of Open Screen Protocol

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -49,10 +49,6 @@ jobs:
         uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
-          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
-          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-secondscreen/2022Apr/0007.html
-          W3C_BUILD_OVERRIDE: |
-            status: WD
 
       - name: Generate application_messages.html
         run: python scripts/pygmentize_dir.py


### PR DESCRIPTION
The spec is about to be re-published as a Discontinued Draft, so stopping the auto-publication to /TR.

Publication to the `gh-pages` branch continues, as that may still be useful. Typically, once the spec gets re-published, the Editor's Draft should also be updated to reflect the discontinued status and redirect people to the Application and Network parts.