### PR TITLE
Add discontinued note, link to /TR, update refs

### DIFF
--- a/application.bs
+++ b/application.bs
@@ -1,11 +1,12 @@
 <pre class='metadata'>
 Title: Open Screen Application Protocol
-Shortname: openscreenprotocol-application
+Shortname: openscreen-application
 Level: None
 Status: w3c/ED
 ED: https://w3c.github.io/openscreenprotocol/application.html
+TR: https://www.w3.org/TR/openscreen-application/
 Canonical URL: ED
-Editor: Mark Foltz, Google, https://github.com/mfoltzgoogle, w3cid 68454
+Editor: Mark Foltz, Google, https://github.com/markafoltz, w3cid 68454
 Repository: w3c/openscreenprotocol
 Abstract: The Open Screen Application Protocol allows user agents to implement the
           [[PRESENTATION-API|Presentation API]] and the
@@ -40,10 +41,10 @@ urlPrefix: https://w3c.github.io/remote-playback/#dfn-; type: dfn; spec: REMOTE-
     text: remote playback source
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-variable-length-integer-enc; type: dfn; spec: RFC9000; text: Variable-Length Integer Encoding
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-variable-length-integer-enc; type: dfn; spec: RFC9000; text: variable-length integer
-url: https://tools.ietf.org/html/rfc5646#section-2; type: dfn; spec: RFC5646; text: language tag
-url: https://tools.ietf.org/html/rfc4122#section-4.4; type: dfn; spec: RFC4122; text: UUID
-url: https://tools.ietf.org/html/rfc6381#section-3; type: dfn; spec: RFC6381; text: codecs parameter
-url: https://tools.ietf.org/html/rfc8610#section-3; type: dfn; spec: RFC8610; text: concise data definition language
+url: https://datatracker.ietf.org/doc/html/rfc5646#section-2; type: dfn; spec: RFC5646; text: language tag
+url: https://datatracker.ietf.org/doc/html/rfc4122#section-4.4; type: dfn; spec: RFC4122; text: UUID
+url: https://datatracker.ietf.org/doc/html/rfc6381#section-3; type: dfn; spec: RFC6381; text: codecs parameter
+url: https://datatracker.ietf.org/doc/html/rfc8610#section-3; type: dfn; spec: RFC8610; text: concise data definition language
 </pre>
 
 Introduction {#introduction}

--- a/index.bs
+++ b/index.bs
@@ -60,6 +60,22 @@ url: https://tools.ietf.org/html/rfc5280#section-4.2.1.3; type: dfn; spec: RFC52
 url: https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.3; type: dfn; spec: RFC8446; text: signature scheme
 </pre>
 
+<div boilerplate="status">
+    <p> <em>This section describes the status of this document at the time of its publication. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at https://www.w3.org/TR/.</em> </p>
+    <div class="advisement">
+        <p>The Second Screen Working Group split the contents of this document into two independent parts. <strong>Work on this document has been discontinued accordingly</strong>. Please check the new documents for updates.</p>
+        <ul>
+            <li>The <a href="https://www.w3.org/TR/openscreen-network/">Open Screen Network Protocol</a> provides a baseline set of network protocols for browsers and devices to discover each other and establish a secure network connection.</li>
+            <li>The <a href="https://www.w3.org/TR/openscreen-application/">Open Screen Application Protocol</a> allows user agents to implement the Presentation API and the Remote Playback API in an interoperable fashion.</li>
+        </ul>
+    </div>
+    <p> This document was published by the <a href="https://www.w3.org/groups/wg/secondscreen">Second Screen Working Group</a> as an Editor's Draft.</p>
+    <p>Publication as an Editor’s Draft does not imply endorsement by W3C and its Members. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
+    <p> This document was produced by a group operating under the <a class="css" data-link-type="property" href="https://www.w3.org/policies/patent-policy/" id="sotd_patent">W3C Patent Policy</a>. <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/groups/wg/secondscreen/ipr/" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/policies/patent-policy/#def-essential">Essential
+    Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
+    <p> This document is governed by the <a href="https://www.w3.org/policies/process/20231103/" id="w3c_process_revision">03 November 2023 W3C Process Document</a>. </p>
+</div>
+
 Introduction {#introduction}
 ============================
 

--- a/network.bs
+++ b/network.bs
@@ -1,9 +1,10 @@
 <pre class='metadata'>
 Title: Open Screen Network Protocol
-Shortname: openscreenprotocol-network
+Shortname: openscreen-network
 Level: None
 Status: w3c/ED
 ED: https://w3c.github.io/openscreenprotocol/network.html
+TR: https://www.w3.org/TR/openscreen-network/
 Canonical URL: ED
 Editor: Mark Foltz, Google, https://github.com/markafoltz, w3cid 68454
 Repository: w3c/openscreenprotocol
@@ -20,19 +21,19 @@ url: https://datatracker.ietf.org/doc/html/rfc9000#name-connection_close-frames;
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-variable-length-integer-enc; type: dfn; spec: RFC9000; text: Variable-Length Integer Encoding
 url: https://datatracker.ietf.org/doc/html/rfc9000#name-variable-length-integer-enc; type: dfn; spec: RFC9000; text: variable-length integer
 url: https://datatracker.ietf.org/doc/html/rfc9000#section-4.6; type: dfn; spec: RFC9000; text: max_streams
-url: https://tools.ietf.org/html/rfc6762#section-9; type: dfn; spec: RFC6762; text: conflict resolution
-url: https://tools.ietf.org/html/rfc6763#section-4.1; type: dfn; spec: RFC6763; text: service instance name
-url: https://tools.ietf.org/html/rfc6763#section-4.1.1; type: dfn; spec: RFC6763; text: instance name
-url: https://tools.ietf.org/html/rfc6763#section-7; type: dfn; spec: RFC6763; text: service name
-url: https://tools.ietf.org/html/rfc4122#section-4.4; type: dfn; spec: RFC4122; text: UUID
-url: https://tools.ietf.org/html/rfc8122#section-5; type: dfn; spec: RFC8122; text: sha-256
-url: https://tools.ietf.org/html/rfc8122#section-5; type: dfn; spec: RFC8122; text: sha-512
-url: https://tools.ietf.org/html/rfc8122#section-5; type: dfn; spec: RFC8122; text: md2
-url: https://tools.ietf.org/html/rfc8122#section-5; type: dfn; spec: RFC8122; text: md5
-url: https://tools.ietf.org/html/rfc6381#section-3; type: dfn; spec: RFC6381; text: codecs parameter
-url: https://tools.ietf.org/html/rfc8610#section-3; type: dfn; spec: RFC8610; text: concise data definition language
+url: https://datatracker.ietf.org/doc/html/rfc6762#section-9; type: dfn; spec: RFC6762; text: conflict resolution
+url: https://datatracker.ietf.org/doc/html/rfc6763#section-4.1; type: dfn; spec: RFC6763; text: service instance name
+url: https://datatracker.ietf.org/doc/html/rfc6763#section-4.1.1; type: dfn; spec: RFC6763; text: instance name
+url: https://datatracker.ietf.org/doc/html/rfc6763#section-7; type: dfn; spec: RFC6763; text: service name
+url: https://datatracker.ietf.org/doc/html/rfc4122#section-4.4; type: dfn; spec: RFC4122; text: UUID
+url: https://datatracker.ietf.org/doc/html/rfc8122#section-5; type: dfn; spec: RFC8122; text: sha-256
+url: https://datatracker.ietf.org/doc/html/rfc8122#section-5; type: dfn; spec: RFC8122; text: sha-512
+url: https://datatracker.ietf.org/doc/html/rfc8122#section-5; type: dfn; spec: RFC8122; text: md2
+url: https://datatracker.ietf.org/doc/html/rfc8122#section-5; type: dfn; spec: RFC8122; text: md5
+url: https://datatracker.ietf.org/doc/html/rfc6381#section-3; type: dfn; spec: RFC6381; text: codecs parameter
+url: https://datatracker.ietf.org/doc/html/rfc8610#section-3; type: dfn; spec: RFC8610; text: concise data definition language
 url: https://www.iso.org/standard/62021.html#; type: dfn; spec: iso18004; text: QR code
-url: https://tools.ietf.org/html/rfc5280#section-4.2.1.3; type: dfn; spec: RFC5280; text: digitalSignature
+url: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3; type: dfn; spec: RFC5280; text: digitalSignature
 url: https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.3; type: dfn; spec: RFC8446; text: signature scheme
 </pre>
 
@@ -57,8 +58,8 @@ The fundamental flow of the network protocol is:
     network.
 - Use of [[!RFC8446|TLS 1.3]] with self-signed certificates to establish an
     initial, unauthenticated connection.
-- Use of \[SPAKE2](https://tools.ietf.org/html/draft-irtf-cfrg-spake2-26) to
-    validate mutual identity and exchange certificates.
+- Use of [[!RFC9382|SPAKE2]] to validate mutual identity and exchange
+    certificates.
 - Use of [[!RFC9000|QUIC]] as a transport layer over IP.
 
 The flow chart in [[#appendix-c]] illustrates the entire sequence of events.
@@ -480,15 +481,14 @@ Issue(242): [Meta] Track CFRG PAKE competition outcome
 For all messages and objects defined in this section, see [[#appendix-a]] for
 the full CDDL definitions.
 
-The default authentication method is
-\[SPAKE2](https://tools.ietf.org/html/draft-irtf-cfrg-spake2-26) with
-the following cipher suite:
+The default authentication method is [[RFC9382|SPAKE2]] with the following
+cipher suite:
 
-1. Elliptic curve is \[edwards25519](https://tools.ietf.org/html/rfc7748#page-4).
-2. Hash function is \[SHA-256](https://tools.ietf.org/html/rfc6234).
-3. Key derivation function is \[HKDF](https://tools.ietf.org/html/rfc5869).
-4. Message authentication code is \[HMAC](https://tools.ietf.org/html/rfc2104).
-5. Password hash function is \[SHA-512](https://tools.ietf.org/html/rfc6234).
+1. Elliptic curve is [[RFC7748#section-4.1|edwards25519]].
+2. Hash function is [[RFC6234|SHA-256]].
+3. Key derivation function is [[RFC5869|HKDF]].
+4. Message authentication code is [[RFC2104|HMAC]].
+5. Password hash function is [[RFC6234|SHA-512]].
 
 Open Screen Network Protocol does not use a memory-hard hash function to hash PSKs with
 SPAKE2 and uses SHA-512 instead, as the PSK is one-time use and is not stored in


### PR DESCRIPTION
This adds a note to the Status of This Document section of the previous Open Screen Protocol to note that the work was discontinued and redirect to the split documents (I copied the entire section because that makes life easier for Bikeshed, we shouldn't need to update that document any time soon in any case).

This also updates the references to IETF documents used in the Application and Network documents, and adds the links to the /TR versions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/pull/356.html" title="Last updated on Dec 11, 2024, 2:37 PM UTC (a78a59d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/openscreenprotocol/356/ed2685d...a78a59d.html" title="Last updated on Dec 11, 2024, 2:37 PM UTC (a78a59d)">Diff</a>