### PR TITLE
Add missing parameters to enable auto-publication of split docs

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -60,6 +60,9 @@ jobs:
           TOOLCHAIN: bikeshed
           GH_PAGES_BRANCH: gh-pages
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN_APPLICATION }}
+          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-secondscreen/2022Apr/0007.html
+          W3C_BUILD_OVERRIDE: |
+            status: WD
 
       - name: Generate network_messages.html
         run: python scripts/pygmentize_dir.py
@@ -71,3 +74,6 @@ jobs:
           TOOLCHAIN: bikeshed
           GH_PAGES_BRANCH: gh-pages
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN_NETWORK }}
+          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-secondscreen/2022Apr/0007.html
+          W3C_BUILD_OVERRIDE: |
+            status: WD


### PR DESCRIPTION
The spec-prod action needs a couple of additional parameters that weren't set.

I'll add the Echidna tokens once #356 is merged (needed to have the right parameters in the documents themselves)