### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 BIKESHED ?= bikeshed
 BIKESHED_ARGS ?= --print=plain
 
-.PHONY: lint watch watch-app watch-net all
+# Define all spec source files
+BS_SOURCES = index.bs application.bs network.bs
 
-# TODO: Generalize targets to reduce duplication.
+.PHONY: lint watch all
 
 all: index.html application.html network.html
 
@@ -16,28 +17,22 @@ application.html: application.bs application_messages.html
 network.html: network.bs network_messages.html
 	$(BIKESHED) $(BIKESHED_ARGS) spec $<
 
-messages_appendix.html: messages_appendix.cddl scripts/pygmentize_dir.py scripts/cddl_lexer.py scripts/openscreen_cddl_dfns.py
-	./scripts/pygmentize_dir.py
+CDDL_SOURCES = messages_appendix.cddl application_messages.cddl network_messages.cddl
+CDDL_OUTPUTS = messages_appendix.html application_messages.html network_messages.html
+PYGMENTIZE_DIR = ./scripts/pygmentize_dir.py
+MESSAGE_SCRIPTS = $(PYGMENTIZE_DIR) scripts/cddl_lexer.py scripts/openscreen_cddl_dfns.py
 
-application_messages.html: application_messages.cddl scripts/pygmentize_dir.py scripts/cddl_lexer.py scripts/openscreen_cddl_dfns.py
-	./scripts/pygmentize_dir.py
+$(CDDL_OUTPUTS) : $(CDDL_SOURCES) $(MESSAGE_SCRIPTS)
+	$(PYGMENTIZE_DIR)
 
-network_messages.html: network_messages.cddl scripts/pygmentize_dir.py scripts/cddl_lexer.py scripts/openscreen_cddl_dfns.py
-	./scripts/pygmentize_dir.py
+lint: $(BS_SOURCES)
+	@for file in $(BS_SOURCES); do \
+		echo "Linting $$file..."; \
+		$(BIKESHED) $(BIKESHED_ARGS) --dry-run --die-when=late --line-numbers spec $$file; \
+	done
 
-lint: index.bs
-	$(BIKESHED) $(BIKESHED_ARGS) --dry-run --force spec --line-numbers $<
-
-watch: index.bs
-	@echo 'Browse to file://${PWD}/index.html'
-	$(BIKESHED) $(BIKESHED_ARGS) watch $<
-
-watch-app: application.bs
-	@echo 'Browse to file://${PWD}/application.html'
-	$(BIKESHED) $(BIKESHED_ARGS) watch $<
-
-watch-net: network.bs
-	@echo 'Browse to file://${PWD}/network.html'
-	$(BIKESHED) $(BIKESHED_ARGS) watch $<
-
-
+watch: $(BS_SOURCES)
+	@for file in $(BS_SOURCES); do \
+		echo "Browse to file://${PWD}/$$file"; \
+		( $(BIKESHED) $(BIKESHED_ARGS) watch $$file & ) \
+	done


### PR DESCRIPTION
Update bikeshed flags for lint target based on feedback in webmachinelearning/webmcp#77.

This also simplifies the Makefile and removes redundant rules.